### PR TITLE
New line at the end of `SourceSpecs` text blocks

### DIFF
--- a/src/main/java/org/openrewrite/java/recipes/SourceSpecTextBlockNewLine.java
+++ b/src/main/java/org/openrewrite/java/recipes/SourceSpecTextBlockNewLine.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2025 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.java.recipes;
+
+import org.openrewrite.ExecutionContext;
+import org.openrewrite.Recipe;
+import org.openrewrite.TreeVisitor;
+import org.openrewrite.internal.ListUtils;
+import org.openrewrite.java.JavaIsoVisitor;
+import org.openrewrite.java.tree.J;
+import org.openrewrite.java.tree.Space;
+import org.openrewrite.java.tree.TypeUtils;
+
+import java.util.Arrays;
+import java.util.StringJoiner;
+import java.util.regex.Pattern;
+
+public class SourceSpecTextBlockNewLine extends Recipe {
+    @Override
+    public String getDisplayName() {
+        return "New line at the end of `SourceSpecs` text blocks";
+    }
+
+    @Override
+    public String getDescription() {
+        return "Text blocks that assert before and after source code should have a new line after it is closed.";
+    }
+}

--- a/src/test/java/org/openrewrite/java/recipes/SourceSpecTextBlockNewLineTest.java
+++ b/src/test/java/org/openrewrite/java/recipes/SourceSpecTextBlockNewLineTest.java
@@ -1,0 +1,156 @@
+/*
+ * Copyright 2025 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.java.recipes;
+
+import org.junit.jupiter.api.Test;
+import org.openrewrite.java.JavaParser;
+import org.openrewrite.test.RecipeSpec;
+import org.openrewrite.test.RewriteTest;
+
+import static org.openrewrite.java.Assertions.java;
+
+class SourceSpecTextBlockNewLineTest implements RewriteTest {
+
+    @Override
+    public void defaults(RecipeSpec spec) {
+        spec.recipe(new SourceSpecTextBlockNewLine())
+          .parser(JavaParser.fromJavaVersion().classpath(JavaParser.runtimeClasspath()));
+    }
+
+    @Test
+    void newlineAfterClosing() {
+        rewriteRun(
+          spec -> spec.expectedCyclesThatMakeChanges(2),
+          java(
+            """
+              import org.openrewrite.test.RewriteTest;
+              import static org.openrewrite.test.SourceSpecs.text;
+
+              class MyRecipeTest implements RewriteTest {
+                  void test() {
+                    rewriteRun(
+                       text(
+                          \"""
+                           class Test {
+              \s
+                              \s
+                               void test() {
+                                   System.out.println("Hello, world!");
+                               }
+                           }
+                           \""")
+                    );
+                  }
+              }
+              """,
+
+            """
+              import org.openrewrite.test.RewriteTest;
+              import static org.openrewrite.test.SourceSpecs.text;
+
+              class MyRecipeTest implements RewriteTest {
+                  void test() {
+                    rewriteRun(
+                       text(
+                          ""\"
+                           class Test {
+              \s
+                              \s
+                               void test() {
+                                   System.out.println("Hello, world!");
+                               }
+                           }
+                           \"""
+                       )
+                    );
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void newlineBetweenMultipleParameters() {
+        rewriteRun(
+          spec -> spec.expectedCyclesThatMakeChanges(2),
+          java(
+            """
+              import org.openrewrite.test.RewriteTest;
+              import static org.openrewrite.test.SourceSpecs.text;
+
+              class MyRecipeTest implements RewriteTest {
+                  void test() {
+                    rewriteRun(
+                       text(
+                          \"""
+                           class Test {
+              \s
+                              \s
+                               void test() {
+                                   System.out.println("Hello, world!");
+                               }
+                           }
+                           \""", ""\"
+                           class Test {
+              \s
+                              \s
+                               void test() {
+                                   System.out.println("Hello, world!");
+                               }
+                           }
+                           ""\"
+                       )
+                    );
+                  }
+              }
+              """,
+
+            """
+              import org.openrewrite.test.RewriteTest;
+              import static org.openrewrite.test.SourceSpecs.text;
+
+              class MyRecipeTest implements RewriteTest {
+                  void test() {
+                    rewriteRun(
+                       text(
+                          \"""
+                           class Test {
+              \s
+                              \s
+                               void test() {
+                                   System.out.println("Hello, world!");
+                               }
+                           }
+                           \""",
+                          ""\"
+                           class Test {
+              \s
+                              \s
+                               void test() {
+                                   System.out.println("Hello, world!");
+                               }
+                           }
+                           ""\"
+                       )
+                    );
+                  }
+              }
+              """
+          )
+        );
+    }
+}


### PR DESCRIPTION
## What's changed?

Ensure that there is a new line after the closure of `SourceSpecs` text blocks.

## What's your motivation?

related to https://github.com/openrewrite/rewrite-rewrite/issues/3

## Anything in particular you'd like reviewers to focus on?
<!-- You can also start a discussion on particular aspects of your implementation on the files tab yourself. -->

## Anyone you would like to review specifically?
<!-- @mention them here -->

## Have you considered any alternatives or workarounds?
<!-- Any other ways to solve the problem, or ways to work around the problem. -->

## Any additional context
<!-- Any thoughts you would like to share in addition to the above. -->

### Checklist
- [ ] I've added unit tests to cover both positive and negative cases
- [ ] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [ ] I've used the IntelliJ IDEA auto-formatter on affected files
