### PR TITLE
Correct placement for `examples.yml` based on test class location

### DIFF
--- a/src/main/java/org/openrewrite/java/recipes/ExamplesExtractor.java
+++ b/src/main/java/org/openrewrite/java/recipes/ExamplesExtractor.java
@@ -26,7 +26,6 @@ import org.openrewrite.internal.StringUtils;
 import org.openrewrite.java.AnnotationMatcher;
 import org.openrewrite.java.JavaIsoVisitor;
 import org.openrewrite.java.MethodMatcher;
-import org.openrewrite.java.marker.JavaProject;
 import org.openrewrite.java.search.UsesType;
 import org.openrewrite.java.trait.Annotated;
 import org.openrewrite.java.trait.Literal;
@@ -118,18 +117,14 @@ public class ExamplesExtractor extends ScanningRecipe<ExamplesExtractor.Accumula
         YamlPrinter yamlPrinter = new YamlPrinter();
         YamlParser yamlParser = YamlParser.builder().build();
         List<SourceFile> yamlRecipeExampleSourceFiles = new ArrayList<>();
-        for (Map.Entry<JavaProject, Map<String, List<RecipeExample>>> entry : acc.projectRecipeExamples.entrySet()) {
+        for (Map.Entry<Path, Map<String, List<RecipeExample>>> entry : acc.projectRecipeExamples.entrySet()) {
             if (entry.getValue().isEmpty()) {
                 continue;
             }
             String yaml = yamlPrinter.print(entry.getValue());
-            Path targetPath = Paths.get(
-                    "/", entry.getKey().getProjectName(), // FIXME Use sourceset instead
-                    "src/main/resources/META-INF/rewrite/examples.yml"
-            );
-            if (!acc.existingExampleFiles.contains(targetPath)) {
+            if (!acc.existingExampleFiles.contains(entry.getKey())) {
                 yamlParser.parse(yaml)
-                        .<SourceFile>map(sf -> sf.withSourcePath(targetPath)
+                        .<SourceFile>map(sf -> sf.withSourcePath(entry.getKey())
                                 .withMarkers(Markers.build(singleton(new Written(Tree.randomId())))))
                         .forEach(yamlRecipeExampleSourceFiles::add);
             }
@@ -144,17 +139,13 @@ public class ExamplesExtractor extends ScanningRecipe<ExamplesExtractor.Accumula
             public Documents visitDocuments(Documents doc, ExecutionContext ctx) {
                 if (acc.existingExampleFiles.contains(doc.getSourcePath()) &&
                         !doc.getMarkers().findFirst(Written.class).isPresent()) {
-                    YamlPrinter yamlPrinter = new YamlPrinter();
-                    YamlParser yamlParser = YamlParser.builder().build();
-                    for (Map.Entry<JavaProject, Map<String, List<RecipeExample>>> entry : acc.projectRecipeExamples.entrySet()) { // FIXME Overwrite only matching file
-                        String yaml = yamlPrinter.print(entry.getValue());
-                        Optional<SourceFile> first = yamlParser.parse(yaml).findFirst();
-                        if (first.isPresent()) {
-                            SourceFile sourceFile = first.get();
-                            if (sourceFile instanceof Documents) {
-                                return doc.withDocuments(((Documents) sourceFile).getDocuments())
-                                        .withMarkers(Markers.build(singleton(new Written(Tree.randomId()))));
-                            }
+                    String yaml = new YamlPrinter().print(acc.projectRecipeExamples.get(doc.getSourcePath()));
+                    Optional<SourceFile> first = YamlParser.builder().build().parse(yaml).findFirst();
+                    if (first.isPresent()) {
+                        SourceFile sourceFile = first.get();
+                        if (sourceFile instanceof Documents) {
+                            return doc.withDocuments(((Documents) sourceFile).getDocuments())
+                                    .withMarkers(Markers.build(singleton(new Written(Tree.randomId()))));
                         }
                     }
                 }
@@ -166,8 +157,8 @@ public class ExamplesExtractor extends ScanningRecipe<ExamplesExtractor.Accumula
     @Value
     public static class Accumulator {
         List<Path> existingExampleFiles = new ArrayList<>();
-        // Project -> RecipeName -> Examples
-        Map<JavaProject, Map<String, List<RecipeExample>>> projectRecipeExamples = new HashMap<>();
+        // Target example file path -> RecipeName -> Examples
+        Map<Path, Map<String, List<RecipeExample>>> projectRecipeExamples = new HashMap<>();
     }
 
     @Value
@@ -177,7 +168,6 @@ public class ExamplesExtractor extends ScanningRecipe<ExamplesExtractor.Accumula
     }
 
     static class ExamplesExtractorVisitor extends JavaIsoVisitor<ExecutionContext> {
-        private static final String PROJECT_KEY = "projectName";
         private static final String RECIPE_KEY = "recipeName";
         private static final String DESCRIPTION_KEY = "description";
 
@@ -185,17 +175,6 @@ public class ExamplesExtractor extends ScanningRecipe<ExamplesExtractor.Accumula
 
         public ExamplesExtractorVisitor(Accumulator acc) {
             this.acc = acc;
-        }
-
-        @Override
-        public @Nullable J visit(@Nullable Tree tree, ExecutionContext ctx) {
-            if (tree instanceof JavaSourceFile) {
-                tree.getMarkers().findFirst(JavaProject.class).ifPresent(javaProject -> {
-                    getCursor().putMessage(PROJECT_KEY, javaProject);
-                    acc.projectRecipeExamples.computeIfAbsent(javaProject, key -> new TreeMap<>());
-                });
-            }
-            return super.visit(tree, ctx);
         }
 
         @Override
@@ -236,9 +215,8 @@ public class ExamplesExtractor extends ScanningRecipe<ExamplesExtractor.Accumula
             }
 
             // Through cursor, retrieve the project, recipe and description we've visited so far
-            JavaProject project = getCursor().getNearestMessage(PROJECT_KEY);
             RecipeNameAndParameters recipe = getCursor().getNearestMessage(RECIPE_KEY); // Default or local spec recipe
-            if (project == null || recipe == null) {
+            if (recipe == null) {
                 return method; // Some parser tests do not include a recipe
             }
             String exampleDescription = getCursor().getNearestMessage(DESCRIPTION_KEY);
@@ -254,7 +232,13 @@ public class ExamplesExtractor extends ScanningRecipe<ExamplesExtractor.Accumula
             if (!example.getSources().isEmpty()) {
                 example.setDescription(exampleDescription);
                 example.setParameters(recipe.getParameters());
-                acc.projectRecipeExamples.get(project).computeIfAbsent(recipe.getName(), key -> new ArrayList<>()).add(example);
+
+                String testSourcePath = getCursor().firstEnclosingOrThrow(J.CompilationUnit.class).getSourcePath().toString();
+                String root = testSourcePath.substring(0, testSourcePath.indexOf("src/test/java"));
+                Path targetPath = Paths.get(root).resolve("src/main/resources/META-INF/rewrite/examples.yml");
+                acc.projectRecipeExamples
+                        .computeIfAbsent(targetPath, key -> new TreeMap<>())
+                        .computeIfAbsent(recipe.getName(), key -> new ArrayList<>()).add(example);
             }
 
             return method;

--- a/src/main/java/org/openrewrite/java/recipes/ExamplesExtractor.java
+++ b/src/main/java/org/openrewrite/java/recipes/ExamplesExtractor.java
@@ -124,10 +124,8 @@ public class ExamplesExtractor extends ScanningRecipe<ExamplesExtractor.Accumula
             }
             String yaml = yamlPrinter.print(entry.getValue());
             Path targetPath = Paths.get(
-                    "/", entry.getKey().getProjectName(),
-                    "src/main/resources",
-                    "META-INF/rewrite",
-                    "examples.yml"
+                    "/", entry.getKey().getProjectName(), // FIXME Use sourceset instead
+                    "src/main/resources/META-INF/rewrite/examples.yml"
             );
             if (!acc.existingExampleFiles.contains(targetPath)) {
                 yamlParser.parse(yaml)
@@ -148,7 +146,7 @@ public class ExamplesExtractor extends ScanningRecipe<ExamplesExtractor.Accumula
                         !doc.getMarkers().findFirst(Written.class).isPresent()) {
                     YamlPrinter yamlPrinter = new YamlPrinter();
                     YamlParser yamlParser = YamlParser.builder().build();
-                    for (Map.Entry<JavaProject, Map<String, List<RecipeExample>>> entry : acc.projectRecipeExamples.entrySet()) {
+                    for (Map.Entry<JavaProject, Map<String, List<RecipeExample>>> entry : acc.projectRecipeExamples.entrySet()) { // FIXME Overwrite only matching file
                         String yaml = yamlPrinter.print(entry.getValue());
                         Optional<SourceFile> first = yamlParser.parse(yaml).findFirst();
                         if (first.isPresent()) {

--- a/src/test/java/org/openrewrite/java/recipes/ExamplesExtractorTest.java
+++ b/src/test/java/org/openrewrite/java/recipes/ExamplesExtractorTest.java
@@ -69,7 +69,8 @@ class ExamplesExtractorTest implements RewriteTest {
             "project",
             srcMainJava(java(RECIPE_JAVA_FILE, SourceSpec::skip)),
             //language=java
-            srcTestJava(java(
+            srcTestJava(
+              java(
                 """
                   package org.openrewrite.staticanalysis;
 
@@ -148,7 +149,7 @@ class ExamplesExtractorTest implements RewriteTest {
                       }
                     language: java
                 """,
-              spec -> spec.path("/project/src/main/resources/META-INF/rewrite/examples.yml")
+              spec -> spec.path("src/main/resources/META-INF/rewrite/examples.yml")
             )
           )
         );
@@ -161,7 +162,8 @@ class ExamplesExtractorTest implements RewriteTest {
           mavenProject(
             "project",
             //language=java
-            srcTestJava(java(
+            srcTestJava(
+              java(
                 """
                   import org.junit.jupiter.api.Test;
                   import org.openrewrite.DocumentExample;
@@ -215,7 +217,7 @@ class ExamplesExtractorTest implements RewriteTest {
                       class A {}
                     language: java
                 \n""",
-              spec -> spec.path("/project/src/main/resources/META-INF/rewrite/examples.yml")
+              spec -> spec.path("src/main/resources/META-INF/rewrite/examples.yml")
             )
           )
         );
@@ -228,25 +230,27 @@ class ExamplesExtractorTest implements RewriteTest {
           mavenProject(
             "project",
             //language=java
-            java(
-              """
-                package org.openrewrite.java;
-
-                import org.junit.jupiter.api.Test;
-                import org.openrewrite.DocumentExample;
-                import org.openrewrite.test.RewriteTest;
-
-                import static org.openrewrite.java.Assertions.java;
-
-                class ParserTest implements RewriteTest {
-
-                    @DocumentExample
-                    @Test
-                    void parseA() {
-                        rewriteRun(java("class A {]"));
-                    }
-                }
+            srcTestJava(
+              java(
                 """
+                  package org.openrewrite.java;
+
+                  import org.junit.jupiter.api.Test;
+                  import org.openrewrite.DocumentExample;
+                  import org.openrewrite.test.RewriteTest;
+
+                  import static org.openrewrite.java.Assertions.java;
+
+                  class ParserTest implements RewriteTest {
+
+                      @DocumentExample
+                      @Test
+                      void parseA() {
+                          rewriteRun(java("class A {]"));
+                      }
+                  }
+                  """
+              )
             )
           )
         );
@@ -260,50 +264,52 @@ class ExamplesExtractorTest implements RewriteTest {
             "project",
             java(RECIPE_JAVA_FILE, SourceSpec::skip),
             // language=java
-            java(
-              """
-                package org.openrewrite.staticanalysis;
-
-                import org.junit.jupiter.api.Test;
-                import org.openrewrite.DocumentExample;
-                import org.openrewrite.test.RecipeSpec;
-                import org.openrewrite.test.RewriteTest;
-
-                import static org.openrewrite.java.Assertions.java;
-
-                class ChainStringBuilderAppendCallsTest implements RewriteTest {
-
-                    @DocumentExample("Objects concatenation.")
-                    @Test
-                    void objectsConcatenation() {
-                        rewriteRun(
-                          spec -> spec.recipe(new ChainStringBuilderAppendCalls()),
-                          java(
-                            \"""
-                              class A {
-                                  void method1() {
-                                      StringBuilder sb = new StringBuilder();
-                                      String op = "+";
-                                      sb.append("A" + op + "B");
-                                      sb.append(1 + op + 2);
-                                  }
-                              }
-                              \""",
-                            \"""
-                              class A {
-                                  void method1() {
-                                      StringBuilder sb = new StringBuilder();
-                                      String op = "+";
-                                      sb.append("A").append(op).append("B");
-                                      sb.append(1).append(op).append(2);
-                                  }
-                              }
-                              \"""
-                          )
-                        );
-                    }
-                }
+            srcTestJava(
+              java(
                 """
+                  package org.openrewrite.staticanalysis;
+
+                  import org.junit.jupiter.api.Test;
+                  import org.openrewrite.DocumentExample;
+                  import org.openrewrite.test.RecipeSpec;
+                  import org.openrewrite.test.RewriteTest;
+
+                  import static org.openrewrite.java.Assertions.java;
+
+                  class ChainStringBuilderAppendCallsTest implements RewriteTest {
+
+                      @DocumentExample("Objects concatenation.")
+                      @Test
+                      void objectsConcatenation() {
+                          rewriteRun(
+                            spec -> spec.recipe(new ChainStringBuilderAppendCalls()),
+                            java(
+                              \"""
+                                class A {
+                                    void method1() {
+                                        StringBuilder sb = new StringBuilder();
+                                        String op = "+";
+                                        sb.append("A" + op + "B");
+                                        sb.append(1 + op + 2);
+                                    }
+                                }
+                                \""",
+                              \"""
+                                class A {
+                                    void method1() {
+                                        StringBuilder sb = new StringBuilder();
+                                        String op = "+";
+                                        sb.append("A").append(op).append("B");
+                                        sb.append(1).append(op).append(2);
+                                    }
+                                }
+                                \"""
+                            )
+                          );
+                      }
+                  }
+                  """
+              )
             ),
             //language=yaml
             yaml(
@@ -335,7 +341,7 @@ class ExamplesExtractorTest implements RewriteTest {
                       }
                     language: java
                 """,
-              spec -> spec.path("/project/src/main/resources/META-INF/rewrite/examples.yml")
+              spec -> spec.path("src/main/resources/META-INF/rewrite/examples.yml")
             )
           )
         );
@@ -350,50 +356,52 @@ class ExamplesExtractorTest implements RewriteTest {
             "project",
             java(RECIPE_JAVA_FILE, SourceSpec::skip),
             //language=java
-            java(
-              """
-                package org.openrewrite.staticanalysis;
-
-                import org.junit.jupiter.api.Test;
-                import org.openrewrite.DocumentExample;
-                import org.openrewrite.test.RecipeSpec;
-                import org.openrewrite.test.RewriteTest;
-
-                import static org.openrewrite.java.Assertions.java;
-
-                class ChainStringBuilderAppendCallsTest implements RewriteTest {
-
-                    @DocumentExample
-                    @Test
-                    void objectsConcatenation() {
-                        rewriteRun(
-                          spec -> spec.recipe(new ChainStringBuilderAppendCalls()),
-                          java(
-                            \"""
-                              class A {
-                                  void method1() {
-                                      StringBuilder sb = new StringBuilder();
-                                      String op = "+";
-                                      sb.append("A" + op + "B");
-                                      sb.append(1 + op + 2);
-                                  }
-                              }
-                              \""",
-                            \"""
-                              class A {
-                                  void method1() {
-                                      StringBuilder sb = new StringBuilder();
-                                      String op = "+";
-                                      sb.append("A").append(op).append("B");
-                                      sb.append(1).append(op).append(2);
-                                  }
-                              }
-                              \"""
-                          )
-                        );
-                    }
-                }
+            srcTestJava(
+              java(
                 """
+                  package org.openrewrite.staticanalysis;
+
+                  import org.junit.jupiter.api.Test;
+                  import org.openrewrite.DocumentExample;
+                  import org.openrewrite.test.RecipeSpec;
+                  import org.openrewrite.test.RewriteTest;
+
+                  import static org.openrewrite.java.Assertions.java;
+
+                  class ChainStringBuilderAppendCallsTest implements RewriteTest {
+
+                      @DocumentExample
+                      @Test
+                      void objectsConcatenation() {
+                          rewriteRun(
+                            spec -> spec.recipe(new ChainStringBuilderAppendCalls()),
+                            java(
+                              \"""
+                                class A {
+                                    void method1() {
+                                        StringBuilder sb = new StringBuilder();
+                                        String op = "+";
+                                        sb.append("A" + op + "B");
+                                        sb.append(1 + op + 2);
+                                    }
+                                }
+                                \""",
+                              \"""
+                                class A {
+                                    void method1() {
+                                        StringBuilder sb = new StringBuilder();
+                                        String op = "+";
+                                        sb.append("A").append(op).append("B");
+                                        sb.append(1).append(op).append(2);
+                                    }
+                                }
+                                \"""
+                            )
+                          );
+                      }
+                  }
+                  """
+              )
             ),
             //language=yaml
             yaml(
@@ -425,7 +433,7 @@ class ExamplesExtractorTest implements RewriteTest {
                       }
                     language: java
                 """,
-              spec -> spec.path("/project/src/main/resources/META-INF/rewrite/examples.yml")
+              spec -> spec.path("src/main/resources/META-INF/rewrite/examples.yml")
             )
           )
         );
@@ -483,97 +491,99 @@ class ExamplesExtractorTest implements RewriteTest {
                 """
             ),
             // language=java
-            java(
-              """
-                package org.openrewrite.staticanalysis;
-
-                import org.junit.jupiter.api.Test;
-                import org.openrewrite.DocumentExample;
-                import org.openrewrite.config.Environment;
-                import org.openrewrite.test.RecipeSpec;
-                import org.openrewrite.test.RewriteTest;
-                import org.openrewrite.test.SourceSpec;
-
-                import java.util.List;
-
-                import static org.assertj.core.api.Assertions.assertThat;
-                import static org.openrewrite.java.Assertions.java;
-
-                class DeclarationSiteTypeVarianceTest implements RewriteTest {
-
-                    @Override
-                    public void defaults(RecipeSpec spec) {
-                        spec.recipe(new DeclarationSiteTypeVariance(
-                            List.of("java.util.function.Function<IN, OUT>"),
-                            List.of("java.lang.*"),
-                            true
-                        ));
-                    }
-
-                    @DocumentExample
-                    @Test
-                    void inOutVariance() {
-                        rewriteRun(
-                            java(
-                                \"""
-                                  interface In {}
-                                  interface Out {}
-                                  \"""
-                            ),
-                            java(
-                                \"""
-                                  import java.util.function.Function;
-                                  class Test {
-                                      void test(Function<In, Out> f) {
-                                      }
-                                  }
-                                  \""",
-                                \"""
-                                  import java.util.function.Function;
-                                  class Test {
-                                      void test(Function<? super In, ? extends Out> f) {
-                                      }
-                                  }
-                                  \"""
-                            )
-                        );
-                    }
-
-                    @DocumentExample
-                    @Test
-                    void invariance() {
-                        rewriteRun(
-                            spec -> spec.recipe(new DeclarationSiteTypeVariance(
-                                List.of("java.util.function.Function<INVARIANT, OUT>"),
-                                List.of("java.lang.*"),
-                                null
-                            )),
-                            java(
-                                \"""
-                                  interface In {}
-                                  interface Out {}
-                                  \"""
-                            ),
-                            java(
-                                \"""
-                                  import java.util.function.Function;
-                                  class Test {
-                                      void test(Function<In, Out> f) {
-                                      }
-                                  }
-                                  \""",
-                                \"""
-                                  import java.util.function.Function;
-                                  class Test {
-                                      void test(Function<In, ? extends Out> f) {
-                                      }
-                                  }
-                                  \"""
-                            )
-                        );
-                    }
-                }
+            srcTestJava(
+              java(
                 """
+                  package org.openrewrite.staticanalysis;
+
+                  import org.junit.jupiter.api.Test;
+                  import org.openrewrite.DocumentExample;
+                  import org.openrewrite.config.Environment;
+                  import org.openrewrite.test.RecipeSpec;
+                  import org.openrewrite.test.RewriteTest;
+                  import org.openrewrite.test.SourceSpec;
+
+                  import java.util.List;
+
+                  import static org.assertj.core.api.Assertions.assertThat;
+                  import static org.openrewrite.java.Assertions.java;
+
+                  class DeclarationSiteTypeVarianceTest implements RewriteTest {
+
+                      @Override
+                      public void defaults(RecipeSpec spec) {
+                          spec.recipe(new DeclarationSiteTypeVariance(
+                              List.of("java.util.function.Function<IN, OUT>"),
+                              List.of("java.lang.*"),
+                              true
+                          ));
+                      }
+
+                      @DocumentExample
+                      @Test
+                      void inOutVariance() {
+                          rewriteRun(
+                              java(
+                                  \"""
+                                    interface In {}
+                                    interface Out {}
+                                    \"""
+                              ),
+                              java(
+                                  \"""
+                                    import java.util.function.Function;
+                                    class Test {
+                                        void test(Function<In, Out> f) {
+                                        }
+                                    }
+                                    \""",
+                                  \"""
+                                    import java.util.function.Function;
+                                    class Test {
+                                        void test(Function<? super In, ? extends Out> f) {
+                                        }
+                                    }
+                                    \"""
+                              )
+                          );
+                      }
+
+                      @DocumentExample
+                      @Test
+                      void invariance() {
+                          rewriteRun(
+                              spec -> spec.recipe(new DeclarationSiteTypeVariance(
+                                  List.of("java.util.function.Function<INVARIANT, OUT>"),
+                                  List.of("java.lang.*"),
+                                  null
+                              )),
+                              java(
+                                  \"""
+                                    interface In {}
+                                    interface Out {}
+                                    \"""
+                              ),
+                              java(
+                                  \"""
+                                    import java.util.function.Function;
+                                    class Test {
+                                        void test(Function<In, Out> f) {
+                                        }
+                                    }
+                                    \""",
+                                  \"""
+                                    import java.util.function.Function;
+                                    class Test {
+                                        void test(Function<In, ? extends Out> f) {
+                                        }
+                                    }
+                                    \"""
+                              )
+                          );
+                      }
+                  }
+                  """
+              )
             ),
             //language=yaml
             yaml(
@@ -630,7 +640,7 @@ class ExamplesExtractorTest implements RewriteTest {
                       }
                     language: java
                 """,
-              spec -> spec.path("/project/src/main/resources/META-INF/rewrite/examples.yml")
+              spec -> spec.path("src/main/resources/META-INF/rewrite/examples.yml")
             )
           )
         );
@@ -643,63 +653,65 @@ class ExamplesExtractorTest implements RewriteTest {
           mavenProject(
             "project",
             // language=java
-            java(
-              """
-                package org.openrewrite.java.migrate.net;
-
-                import org.junit.jupiter.api.Test;
-                import org.openrewrite.DocumentExample;
-                import org.openrewrite.config.Environment;
-                import org.openrewrite.test.RecipeSpec;
-                import org.openrewrite.test.RewriteTest;
-
-                import static org.openrewrite.java.Assertions.java;
-
-                class JavaNetAPIsTest implements RewriteTest {
-                    @Override
-                    public void defaults(RecipeSpec spec) {
-                        spec.recipe(
-                          Environment.builder()
-                            .scanRuntimeClasspath("org.openrewrite.java.migrate.net")
-                            .build()
-                            .activateRecipes("org.openrewrite.java.migrate.net.JavaNetAPIs"));
-                    }
-
-                    @DocumentExample
-                    @Test
-                    void multicastSocketGetTTLToGetTimeToLive() {
-                        //language=java
-                        rewriteRun(
-                          java(
-                            ""\"
-                              package org.openrewrite.example;
-
-                              import java.net.MulticastSocket;
-
-                              public class Test {
-                                  public static void method() {
-                                      MulticastSocket s = new MulticastSocket(0);
-                                      s.getTTL();
-                                  }
-                              }
-                              ""\",
-                            ""\"
-                              package org.openrewrite.example;
-
-                              import java.net.MulticastSocket;
-
-                              public class Test {
-                                  public static void method() {
-                                      MulticastSocket s = new MulticastSocket(0);
-                                      s.getTimeToLive();
-                                  }
-                              }
-                              ""\"
-                          )
-                        );
-                    }
-                }
+            srcTestJava(
+              java(
                 """
+                  package org.openrewrite.java.migrate.net;
+
+                  import org.junit.jupiter.api.Test;
+                  import org.openrewrite.DocumentExample;
+                  import org.openrewrite.config.Environment;
+                  import org.openrewrite.test.RecipeSpec;
+                  import org.openrewrite.test.RewriteTest;
+
+                  import static org.openrewrite.java.Assertions.java;
+
+                  class JavaNetAPIsTest implements RewriteTest {
+                      @Override
+                      public void defaults(RecipeSpec spec) {
+                          spec.recipe(
+                            Environment.builder()
+                              .scanRuntimeClasspath("org.openrewrite.java.migrate.net")
+                              .build()
+                              .activateRecipes("org.openrewrite.java.migrate.net.JavaNetAPIs"));
+                      }
+
+                      @DocumentExample
+                      @Test
+                      void multicastSocketGetTTLToGetTimeToLive() {
+                          //language=java
+                          rewriteRun(
+                            java(
+                              ""\"
+                                package org.openrewrite.example;
+
+                                import java.net.MulticastSocket;
+
+                                public class Test {
+                                    public static void method() {
+                                        MulticastSocket s = new MulticastSocket(0);
+                                        s.getTTL();
+                                    }
+                                }
+                                ""\",
+                              ""\"
+                                package org.openrewrite.example;
+
+                                import java.net.MulticastSocket;
+
+                                public class Test {
+                                    public static void method() {
+                                        MulticastSocket s = new MulticastSocket(0);
+                                        s.getTimeToLive();
+                                    }
+                                }
+                                ""\"
+                            )
+                          );
+                      }
+                  }
+                  """
+              )
             ),
             //language=yaml
             yaml(
@@ -734,7 +746,7 @@ class ExamplesExtractorTest implements RewriteTest {
                       }
                     language: java
                 """,
-              spec -> spec.path("/project/src/main/resources/META-INF/rewrite/examples.yml")
+              spec -> spec.path("src/main/resources/META-INF/rewrite/examples.yml")
             )
           )
         );
@@ -748,32 +760,34 @@ class ExamplesExtractorTest implements RewriteTest {
           mavenProject(
             "project",
             // language=java
-            java(
-              """
-                package org.openrewrite.java.migrate.net;
-
-                import org.junit.jupiter.api.Test;
-                import org.openrewrite.DocumentExample;
-                import org.openrewrite.config.Environment;
-                import org.openrewrite.test.RecipeSpec;
-                import org.openrewrite.test.RewriteTest;
-
-                import static org.openrewrite.java.Assertions.java;
-
-                class JavaNetAPIsTest implements RewriteTest {
-                    @Override
-                    public void defaults(RecipeSpec spec) {
-                        spec.recipeFromResources("org.openrewrite.java.migrate.net.JavaNetAPIs");
-                    }
-
-                    @DocumentExample
-                    @Test
-                    void multicastSocketGetTTLToGetTimeToLive() {
-                        //language=java
-                        rewriteRun(java("class A {}", "class B {}"));
-                    }
-                }
+            srcTestJava(
+              java(
                 """
+                  package org.openrewrite.java.migrate.net;
+
+                  import org.junit.jupiter.api.Test;
+                  import org.openrewrite.DocumentExample;
+                  import org.openrewrite.config.Environment;
+                  import org.openrewrite.test.RecipeSpec;
+                  import org.openrewrite.test.RewriteTest;
+
+                  import static org.openrewrite.java.Assertions.java;
+
+                  class JavaNetAPIsTest implements RewriteTest {
+                      @Override
+                      public void defaults(RecipeSpec spec) {
+                          spec.recipeFromResources("org.openrewrite.java.migrate.net.JavaNetAPIs");
+                      }
+
+                      @DocumentExample
+                      @Test
+                      void multicastSocketGetTTLToGetTimeToLive() {
+                          //language=java
+                          rewriteRun(java("class A {}", "class B {}"));
+                      }
+                  }
+                  """
+              )
             ),
             //language=yaml
             yaml(
@@ -788,7 +802,7 @@ class ExamplesExtractorTest implements RewriteTest {
                     after: class B {}
                     language: java
                 """,
-              spec -> spec.path("/project/src/main/resources/META-INF/rewrite/examples.yml")
+              spec -> spec.path("src/main/resources/META-INF/rewrite/examples.yml")
             )
           )
         );
@@ -801,61 +815,63 @@ class ExamplesExtractorTest implements RewriteTest {
           mavenProject(
             "project",
             // language=java
-            java(
-              """
-                package org.openrewrite.yaml;
-
-                import org.junit.jupiter.api.Test;
-                import org.openrewrite.Issue;
-                import org.openrewrite.DocumentExample;
-                import org.openrewrite.test.RewriteTest;
-
-                import static org.openrewrite.yaml.Assertions.yaml;
-
-                class MergeYamlTest implements RewriteTest {
-
-                    @DocumentExample
-                    @Test
-                    void nonExistentBlock() {
-                        rewriteRun(
-                          spec -> spec.recipe(new MergeYaml(
-                            "$.spec",
-                            //language=yaml
-                            ""\"
-                              lifecycleRule:
-                                  - action:
-                                        type: Delete
-                                    condition:
-                                        age: 7
-                              ""\",
-                            false,
-                            null,
-                            null,
-                            null
-                          )),
-                          yaml(
-                            ""\"
-                              apiVersion: storage.cnrm.cloud.google.com/v1beta1
-                              kind: StorageBucket
-                              spec:
-                                  bucketPolicyOnly: true
-                              ""\",
-                            ""\"
-                              apiVersion: storage.cnrm.cloud.google.com/v1beta1
-                              kind: StorageBucket
-                              spec:
-                                  bucketPolicyOnly: true
-                                  lifecycleRule:
-                                      - action:
-                                            type: Delete
-                                        condition:
-                                            age: 7
-                              ""\"
-                          )
-                        );
-                    }
-                }
+            srcTestJava(
+              java(
                 """
+                  package org.openrewrite.yaml;
+
+                  import org.junit.jupiter.api.Test;
+                  import org.openrewrite.Issue;
+                  import org.openrewrite.DocumentExample;
+                  import org.openrewrite.test.RewriteTest;
+
+                  import static org.openrewrite.yaml.Assertions.yaml;
+
+                  class MergeYamlTest implements RewriteTest {
+
+                      @DocumentExample
+                      @Test
+                      void nonExistentBlock() {
+                          rewriteRun(
+                            spec -> spec.recipe(new MergeYaml(
+                              "$.spec",
+                              //language=yaml
+                              ""\"
+                                lifecycleRule:
+                                    - action:
+                                          type: Delete
+                                      condition:
+                                          age: 7
+                                ""\",
+                              false,
+                              null,
+                              null,
+                              null
+                            )),
+                            yaml(
+                              ""\"
+                                apiVersion: storage.cnrm.cloud.google.com/v1beta1
+                                kind: StorageBucket
+                                spec:
+                                    bucketPolicyOnly: true
+                                ""\",
+                              ""\"
+                                apiVersion: storage.cnrm.cloud.google.com/v1beta1
+                                kind: StorageBucket
+                                spec:
+                                    bucketPolicyOnly: true
+                                    lifecycleRule:
+                                        - action:
+                                              type: Delete
+                                          condition:
+                                              age: 7
+                                ""\"
+                            )
+                          );
+                      }
+                  }
+                  """
+              )
             ),
             //language=yaml
             yaml(
@@ -896,7 +912,7 @@ class ExamplesExtractorTest implements RewriteTest {
                                     age: 7
                     language: yaml
                 """,
-              spec -> spec.path("/project/src/main/resources/META-INF/rewrite/examples.yml")
+              spec -> spec.path("src/main/resources/META-INF/rewrite/examples.yml")
             )
           )
         );
@@ -942,85 +958,86 @@ class ExamplesExtractorTest implements RewriteTest {
                       }
                     language: java
                 """,
-              spec -> spec.path("/project/src/main/resources/META-INF/rewrite/examples.yml")
+              spec -> spec.path("src/main/resources/META-INF/rewrite/examples.yml")
             ),
             //language=java
-            java(
-              """
-                package org.openrewrite.staticanalysis;
+            srcTestJava(
+              java(
+                """
+                  package org.openrewrite.staticanalysis;
 
-                import org.junit.jupiter.api.Test;
-                import org.openrewrite.DocumentExample;
-                import org.openrewrite.java.OrderImports;
-                import org.openrewrite.test.RecipeSpec;
-                import org.openrewrite.test.RewriteTest;
+                  import org.junit.jupiter.api.Test;
+                  import org.openrewrite.DocumentExample;
+                  import org.openrewrite.java.OrderImports;
+                  import org.openrewrite.test.RecipeSpec;
+                  import org.openrewrite.test.RewriteTest;
 
-                import static org.openrewrite.java.Assertions.java;
+                  import static org.openrewrite.java.Assertions.java;
 
-                class OrderImportsTest implements RewriteTest {
-                    @Override
-                    public void defaults(RecipeSpec spec) {
-                        spec.recipe(new OrderImports(null));
-                    }
+                  class OrderImportsTest implements RewriteTest {
+                      @Override
+                      public void defaults(RecipeSpec spec) {
+                          spec.recipe(new OrderImports(null));
+                      }
 
-                    @DocumentExample
-                    @Test
-                    void orderImports() {
-                        rewriteRun(
-                          java(
-                            ""\"
-                              import java.util.List;
-                              class A {
-                              }
-                              ""\",
-                            ""\"
-                              class A {
-                              }
+                      @DocumentExample
+                      @Test
+                      void orderImports() {
+                          rewriteRun(
+                            java(
                               ""\"
-                          )
-                        );
-                    }
-                }
+                                import java.util.List;
+                                class A {
+                                }
+                                ""\",
+                              ""\"
+                                class A {
+                                }
+                                ""\"
+                            )
+                          );
+                      }
+                  }
+                  """
+              ),
+              java(
                 """
-            ),
-            //language=java
-            java(
-              """
-                package org.openrewrite.staticanalysis;
+                  package org.openrewrite.staticanalysis;
 
-                import org.junit.jupiter.api.Test;
-                import org.openrewrite.DocumentExample;
-                import org.openrewrite.java.RemoveUnusedImports;
-                import org.openrewrite.test.RecipeSpec;
-                import org.openrewrite.test.RewriteTest;
+                  import org.junit.jupiter.api.Test;
+                  import org.openrewrite.DocumentExample;
+                  import org.openrewrite.java.RemoveUnusedImports;
+                  import org.openrewrite.test.RecipeSpec;
+                  import org.openrewrite.test.RewriteTest;
 
-                import static org.openrewrite.java.Assertions.java;
+                  import static org.openrewrite.java.Assertions.java;
 
-                class RemoveUnusedImportsTest implements RewriteTest {
-                    @Override
-                    public void defaults(RecipeSpec spec) {
-                        spec.recipe(new RemoveUnusedImports());
-                    }
+                  class RemoveUnusedImportsTest implements RewriteTest {
+                      @Override
+                      public void defaults(RecipeSpec spec) {
+                          spec.recipe(new RemoveUnusedImports());
+                      }
 
-                    @DocumentExample
-                    @Test
-                    void removeUnusedImports() {
-                        rewriteRun(
-                          java(
-                            \"""
-                              import java.util.List;
-                              class A {
-                              }
-                              \""",
-                            \"""
-                              class A {
-                              }
+                      @DocumentExample
+                      @Test
+                      void removeUnusedImports() {
+                          rewriteRun(
+                            java(
                               \"""
-                          )
-                        );
-                    }
-                }
-                """
+                                import java.util.List;
+                                class A {
+                                }
+                                \""",
+                              \"""
+                                class A {
+                                }
+                                \"""
+                            )
+                          );
+                      }
+                  }
+                  """
+              )
             )
           )
         );
@@ -1060,57 +1077,59 @@ class ExamplesExtractorTest implements RewriteTest {
                       }
                     language: java
                 """,
-              spec -> spec.path("/project/src/main/resources/META-INF/rewrite/examples.yml")
+              spec -> spec.path("src/main/resources/META-INF/rewrite/examples.yml")
             ),
             //language=java
-            java(
-              """
-                package org.openrewrite.staticanalysis;
-
-                import org.junit.jupiter.api.Test;
-                import org.openrewrite.DocumentExample;
-                import org.openrewrite.java.OrderImports;
-                import org.openrewrite.test.RecipeSpec;
-                import org.openrewrite.test.RewriteTest;
-
-                import static org.openrewrite.java.Assertions.java;
-
-                class OrderImportsTest implements RewriteTest {
-                    @Override
-                    public void defaults(RecipeSpec spec) {
-                        spec.recipe(new OrderImports(null));
-                    }
-
-                    @DocumentExample
-                    @Test
-                    void orderImports() {
-                        rewriteRun(
-                          java(
-                            ""\"
-                              import java.util.List;
-                              class A {
-                              }
-                              ""\",
-                            ""\"
-                              class A {
-                              }
-                              ""\"
-                          ),
-                          java(
-                            \"""
-                              import java.util.List;
-                              class B {
-                              }
-                              \""",
-                            \"""
-                              class B {
-                              }
-                              \"""
-                          )
-                        );
-                    }
-                }
+            srcTestJava(
+              java(
                 """
+                  package org.openrewrite.staticanalysis;
+
+                  import org.junit.jupiter.api.Test;
+                  import org.openrewrite.DocumentExample;
+                  import org.openrewrite.java.OrderImports;
+                  import org.openrewrite.test.RecipeSpec;
+                  import org.openrewrite.test.RewriteTest;
+
+                  import static org.openrewrite.java.Assertions.java;
+
+                  class OrderImportsTest implements RewriteTest {
+                      @Override
+                      public void defaults(RecipeSpec spec) {
+                          spec.recipe(new OrderImports(null));
+                      }
+
+                      @DocumentExample
+                      @Test
+                      void orderImports() {
+                          rewriteRun(
+                            java(
+                              ""\"
+                                import java.util.List;
+                                class A {
+                                }
+                                ""\",
+                              ""\"
+                                class A {
+                                }
+                                ""\"
+                            ),
+                            java(
+                              \"""
+                                import java.util.List;
+                                class B {
+                                }
+                                \""",
+                              \"""
+                                class B {
+                                }
+                                \"""
+                            )
+                          );
+                      }
+                  }
+                  """
+              )
             )
           )
         );
@@ -1142,46 +1161,48 @@ class ExamplesExtractorTest implements RewriteTest {
                       }
                     language: java
                 """,
-              spec -> spec.path("/projectA/src/main/resources/META-INF/rewrite/examples.yml")
+              spec -> spec.path("src/main/resources/META-INF/rewrite/examples.yml")
             ),
             //language=java
-            java(
-              """
-                package org.openrewrite.staticanalysis;
-
-                import org.junit.jupiter.api.Test;
-                import org.openrewrite.DocumentExample;
-                import org.openrewrite.java.OrderImports;
-                import org.openrewrite.test.RecipeSpec;
-                import org.openrewrite.test.RewriteTest;
-
-                import static org.openrewrite.java.Assertions.java;
-
-                class OrderImportsTest implements RewriteTest {
-                    @Override
-                    public void defaults(RecipeSpec spec) {
-                        spec.recipe(new OrderImports(null));
-                    }
-
-                    @DocumentExample
-                    @Test
-                    void orderImports() {
-                        rewriteRun(
-                          java(
-                            ""\"
-                              import java.util.List;
-                              class A {
-                              }
-                              ""\",
-                            ""\"
-                              class A {
-                              }
-                              ""\"
-                          )
-                        );
-                    }
-                }
+            srcTestJava(
+              java(
                 """
+                  package org.openrewrite.staticanalysis;
+
+                  import org.junit.jupiter.api.Test;
+                  import org.openrewrite.DocumentExample;
+                  import org.openrewrite.java.OrderImports;
+                  import org.openrewrite.test.RecipeSpec;
+                  import org.openrewrite.test.RewriteTest;
+
+                  import static org.openrewrite.java.Assertions.java;
+
+                  class OrderImportsTest implements RewriteTest {
+                      @Override
+                      public void defaults(RecipeSpec spec) {
+                          spec.recipe(new OrderImports(null));
+                      }
+
+                      @DocumentExample
+                      @Test
+                      void orderImports() {
+                          rewriteRun(
+                            java(
+                              ""\"
+                                import java.util.List;
+                                class A {
+                                }
+                                ""\",
+                              ""\"
+                                class A {
+                                }
+                                ""\"
+                            )
+                          );
+                      }
+                  }
+                  """
+              )
             )
           ),
           mavenProject(
@@ -1205,46 +1226,48 @@ class ExamplesExtractorTest implements RewriteTest {
                       }
                     language: java
                 """,
-              spec -> spec.path("/projectB/src/main/resources/META-INF/rewrite/examples.yml")
+              spec -> spec.path("src/main/resources/META-INF/rewrite/examples.yml")
             ),
             //language=java
-            java(
-              """
-                package org.openrewrite.staticanalysis;
-
-                import org.junit.jupiter.api.Test;
-                import org.openrewrite.DocumentExample;
-                import org.openrewrite.java.RemoveUnusedImports;
-                import org.openrewrite.test.RecipeSpec;
-                import org.openrewrite.test.RewriteTest;
-
-                import static org.openrewrite.java.Assertions.java;
-
-                class RemoveUnusedImportsTest implements RewriteTest {
-                    @Override
-                    public void defaults(RecipeSpec spec) {
-                        spec.recipe(new RemoveUnusedImports());
-                    }
-
-                    @DocumentExample
-                    @Test
-                    void removeUnusedImports() {
-                        rewriteRun(
-                          java(
-                            \"""
-                              import java.util.List;
-                              class B {
-                              }
-                              \""",
-                            \"""
-                              class B {
-                              }
-                              \"""
-                          )
-                        );
-                    }
-                }
+            srcTestJava(
+              java(
                 """
+                  package org.openrewrite.staticanalysis;
+
+                  import org.junit.jupiter.api.Test;
+                  import org.openrewrite.DocumentExample;
+                  import org.openrewrite.java.RemoveUnusedImports;
+                  import org.openrewrite.test.RecipeSpec;
+                  import org.openrewrite.test.RewriteTest;
+
+                  import static org.openrewrite.java.Assertions.java;
+
+                  class RemoveUnusedImportsTest implements RewriteTest {
+                      @Override
+                      public void defaults(RecipeSpec spec) {
+                          spec.recipe(new RemoveUnusedImports());
+                      }
+
+                      @DocumentExample
+                      @Test
+                      void removeUnusedImports() {
+                          rewriteRun(
+                            java(
+                              \"""
+                                import java.util.List;
+                                class B {
+                                }
+                                \""",
+                              \"""
+                                class B {
+                                }
+                                \"""
+                            )
+                          );
+                      }
+                  }
+                  """
+              )
             )
           )
         );
@@ -1276,41 +1299,43 @@ class ExamplesExtractorTest implements RewriteTest {
                       }
                     language: java
                 \n""",
-              spec -> spec.path("/projectA/src/main/resources/META-INF/rewrite/examples.yml")
+              spec -> spec.path("src/main/resources/META-INF/rewrite/examples.yml")
             ),
             //language=java
-            java(
-              """
-                package org.openrewrite.staticanalysis;
-
-                import org.junit.jupiter.api.Test;
-                import org.openrewrite.DocumentExample;
-                import org.openrewrite.java.OrderImports;
-                import org.openrewrite.test.RewriteTest;
-
-                import static org.openrewrite.java.Assertions.java;
-
-                class OrderImportsTest implements RewriteTest {
-                    @DocumentExample
-                    @Test
-                    void orderImports() {
-                        rewriteRun(
-                          spec -> spec.recipe(new OrderImports(null)),
-                          java(
-                            ""\"
-                              import java.util.List;
-                              class A {
-                              }
-                              ""\",
-                            ""\"
-                              class A {
-                              }
-                              ""\"
-                          )
-                        );
-                    }
-                }
+            srcTestJava(
+              java(
                 """
+                  package org.openrewrite.staticanalysis;
+
+                  import org.junit.jupiter.api.Test;
+                  import org.openrewrite.DocumentExample;
+                  import org.openrewrite.java.OrderImports;
+                  import org.openrewrite.test.RewriteTest;
+
+                  import static org.openrewrite.java.Assertions.java;
+
+                  class OrderImportsTest implements RewriteTest {
+                      @DocumentExample
+                      @Test
+                      void orderImports() {
+                          rewriteRun(
+                            spec -> spec.recipe(new OrderImports(null)),
+                            java(
+                              ""\"
+                                import java.util.List;
+                                class A {
+                                }
+                                ""\",
+                              ""\"
+                                class A {
+                                }
+                                ""\"
+                            )
+                          );
+                      }
+                  }
+                  """
+              )
             )
           ),
           mavenProject(
@@ -1334,41 +1359,43 @@ class ExamplesExtractorTest implements RewriteTest {
                       }
                     language: java
                 \n""",
-              spec -> spec.path("/projectB/src/main/resources/META-INF/rewrite/examples.yml")
+              spec -> spec.path("src/main/resources/META-INF/rewrite/examples.yml")
             ),
             //language=java
-            java(
-              """
-                package org.openrewrite.staticanalysis;
-
-                import org.junit.jupiter.api.Test;
-                import org.openrewrite.DocumentExample;
-                import org.openrewrite.java.RemoveUnusedImports;
-                import org.openrewrite.test.RewriteTest;
-
-                import static org.openrewrite.java.Assertions.java;
-
-                class RemoveUnusedImportsTest implements RewriteTest {
-                    @DocumentExample
-                    @Test
-                    void removeUnusedImports() {
-                        rewriteRun(
-                          spec -> spec.recipe(new RemoveUnusedImports()),
-                          java(
-                            \"""
-                              import java.util.List;
-                              class B {
-                              }
-                              \""",
-                            \"""
-                              class B {
-                              }
-                              \"""
-                          )
-                        );
-                    }
-                }
+            srcTestJava(
+              java(
                 """
+                  package org.openrewrite.staticanalysis;
+
+                  import org.junit.jupiter.api.Test;
+                  import org.openrewrite.DocumentExample;
+                  import org.openrewrite.java.RemoveUnusedImports;
+                  import org.openrewrite.test.RewriteTest;
+
+                  import static org.openrewrite.java.Assertions.java;
+
+                  class RemoveUnusedImportsTest implements RewriteTest {
+                      @DocumentExample
+                      @Test
+                      void removeUnusedImports() {
+                          rewriteRun(
+                            spec -> spec.recipe(new RemoveUnusedImports()),
+                            java(
+                              \"""
+                                import java.util.List;
+                                class B {
+                                }
+                                \""",
+                              \"""
+                                class B {
+                                }
+                                \"""
+                            )
+                          );
+                      }
+                  }
+                  """
+              )
             )
           )
         );

--- a/src/test/java/org/openrewrite/java/recipes/ExamplesExtractorTest.java
+++ b/src/test/java/org/openrewrite/java/recipes/ExamplesExtractorTest.java
@@ -63,7 +63,6 @@ class ExamplesExtractorTest implements RewriteTest {
     @DocumentExample
     @Test
     void extractJavaExampleWithDefault() {
-        //language=yaml
         rewriteRun(
           mavenProject(
             "project",
@@ -157,7 +156,6 @@ class ExamplesExtractorTest implements RewriteTest {
 
     @Test
     void existingExampleFile() {
-        //language=yaml
         rewriteRun(
           mavenProject(
             "project",
@@ -225,7 +223,6 @@ class ExamplesExtractorTest implements RewriteTest {
 
     @Test
     void parserTestWithoutRecipe() {
-        //language=yaml
         rewriteRun(
           mavenProject(
             "project",
@@ -258,7 +255,6 @@ class ExamplesExtractorTest implements RewriteTest {
 
     @Test
     void extractJavaExampleRecipeInSpec() {
-        //language=yaml
         rewriteRun(
           mavenProject(
             "project",
@@ -349,8 +345,6 @@ class ExamplesExtractorTest implements RewriteTest {
 
     @Test
     void extractJavaExampleWithNoDescription() {
-        // language=java
-        //language=yaml
         rewriteRun(
           mavenProject(
             "project",
@@ -441,7 +435,6 @@ class ExamplesExtractorTest implements RewriteTest {
 
     @Test
     void extractParameters() {
-        //language=yaml
         rewriteRun(
           mavenProject(
             "project",
@@ -648,7 +641,6 @@ class ExamplesExtractorTest implements RewriteTest {
 
     @Test
     void yamlRecipeFromActiveRecipes() {
-        //language=yaml
         rewriteRun(
           mavenProject(
             "project",
@@ -755,7 +747,6 @@ class ExamplesExtractorTest implements RewriteTest {
 
     @Test
     void yamlRecipeFromResources() {
-        //language=yaml
         rewriteRun(
           mavenProject(
             "project",
@@ -810,7 +801,6 @@ class ExamplesExtractorTest implements RewriteTest {
 
     @Test
     void textBlockAsParameter() {
-        //language=yaml
         rewriteRun(
           mavenProject(
             "project",
@@ -920,45 +910,47 @@ class ExamplesExtractorTest implements RewriteTest {
 
     @Test
     void singleProjectWithTwoRecipeTests() {
-        //language=yaml
         rewriteRun(
           mavenProject(
             "project",
-            yaml(
-              null, // newly created
-              """
-                ---
-                type: specs.openrewrite.org/v1beta/example
-                recipeName: org.openrewrite.java.OrderImports
-                examples:
-                - description: ''
-                  parameters:
-                  - 'null'
-                  sources:
-                  - before: |
-                      import java.util.List;
-                      class A {
-                      }
-                    after: |
-                      class A {
-                      }
-                    language: java
-                ---
-                type: specs.openrewrite.org/v1beta/example
-                recipeName: org.openrewrite.java.RemoveUnusedImports
-                examples:
-                - description: ''
-                  sources:
-                  - before: |
-                      import java.util.List;
-                      class A {
-                      }
-                    after: |
-                      class A {
-                      }
-                    language: java
-                """,
-              spec -> spec.path("src/main/resources/META-INF/rewrite/examples.yml")
+            //language=yaml
+            srcMainResources(
+              yaml(
+                null, // newly created
+                """
+                  ---
+                  type: specs.openrewrite.org/v1beta/example
+                  recipeName: org.openrewrite.java.OrderImports
+                  examples:
+                  - description: ''
+                    parameters:
+                    - 'null'
+                    sources:
+                    - before: |
+                        import java.util.List;
+                        class A {
+                        }
+                      after: |
+                        class A {
+                        }
+                      language: java
+                  ---
+                  type: specs.openrewrite.org/v1beta/example
+                  recipeName: org.openrewrite.java.RemoveUnusedImports
+                  examples:
+                  - description: ''
+                    sources:
+                    - before: |
+                        import java.util.List;
+                        class A {
+                        }
+                      after: |
+                        class A {
+                        }
+                      language: java
+                  """,
+                spec -> spec.path("META-INF/rewrite/examples.yml")
+              )
             ),
             //language=java
             srcTestJava(
@@ -1049,35 +1041,37 @@ class ExamplesExtractorTest implements RewriteTest {
         rewriteRun(
           mavenProject(
             "project",
-            yaml(
-              null, // newly created
-              """
-                ---
-                type: specs.openrewrite.org/v1beta/example
-                recipeName: org.openrewrite.java.OrderImports
-                examples:
-                - description: ''
-                  parameters:
-                  - 'null'
-                  sources:
-                  - before: |
-                      import java.util.List;
-                      class A {
-                      }
-                    after: |
-                      class A {
-                      }
-                    language: java
-                  - before: |
-                      import java.util.List;
-                      class B {
-                      }
-                    after: |
-                      class B {
-                      }
-                    language: java
-                """,
-              spec -> spec.path("src/main/resources/META-INF/rewrite/examples.yml")
+            srcMainResources(
+              yaml(
+                null, // newly created
+                """
+                  ---
+                  type: specs.openrewrite.org/v1beta/example
+                  recipeName: org.openrewrite.java.OrderImports
+                  examples:
+                  - description: ''
+                    parameters:
+                    - 'null'
+                    sources:
+                    - before: |
+                        import java.util.List;
+                        class A {
+                        }
+                      after: |
+                        class A {
+                        }
+                      language: java
+                    - before: |
+                        import java.util.List;
+                        class B {
+                        }
+                      after: |
+                        class B {
+                        }
+                      language: java
+                  """,
+                spec -> spec.path("META-INF/rewrite/examples.yml")
+              )
             ),
             //language=java
             srcTestJava(
@@ -1141,27 +1135,29 @@ class ExamplesExtractorTest implements RewriteTest {
         rewriteRun(
           mavenProject(
             "projectA",
-            yaml(
-              null, // newly created
-              """
-                ---
-                type: specs.openrewrite.org/v1beta/example
-                recipeName: org.openrewrite.java.OrderImports
-                examples:
-                - description: ''
-                  parameters:
-                  - 'null'
-                  sources:
-                  - before: |
-                      import java.util.List;
-                      class A {
-                      }
-                    after: |
-                      class A {
-                      }
-                    language: java
-                """,
-              spec -> spec.path("src/main/resources/META-INF/rewrite/examples.yml")
+            srcMainResources(
+              yaml(
+                null, // newly created
+                """
+                  ---
+                  type: specs.openrewrite.org/v1beta/example
+                  recipeName: org.openrewrite.java.OrderImports
+                  examples:
+                  - description: ''
+                    parameters:
+                    - 'null'
+                    sources:
+                    - before: |
+                        import java.util.List;
+                        class A {
+                        }
+                      after: |
+                        class A {
+                        }
+                      language: java
+                  """,
+                spec -> spec.path("META-INF/rewrite/examples.yml")
+              )
             ),
             //language=java
             srcTestJava(
@@ -1208,25 +1204,27 @@ class ExamplesExtractorTest implements RewriteTest {
           mavenProject(
             "projectB",
             //language=yaml
-            yaml(
-              null, // newly created
-              """
-                ---
-                type: specs.openrewrite.org/v1beta/example
-                recipeName: org.openrewrite.java.RemoveUnusedImports
-                examples:
-                - description: ''
-                  sources:
-                  - before: |
-                      import java.util.List;
-                      class B {
-                      }
-                    after: |
-                      class B {
-                      }
-                    language: java
-                """,
-              spec -> spec.path("src/main/resources/META-INF/rewrite/examples.yml")
+            srcMainResources(
+              yaml(
+                null, // newly created
+                """
+                  ---
+                  type: specs.openrewrite.org/v1beta/example
+                  recipeName: org.openrewrite.java.RemoveUnusedImports
+                  examples:
+                  - description: ''
+                    sources:
+                    - before: |
+                        import java.util.List;
+                        class B {
+                        }
+                      after: |
+                        class B {
+                        }
+                      language: java
+                  """,
+                spec -> spec.path("META-INF/rewrite/examples.yml")
+              )
             ),
             //language=java
             srcTestJava(
@@ -1279,27 +1277,29 @@ class ExamplesExtractorTest implements RewriteTest {
         rewriteRun(
           mavenProject(
             "projectA",
-            yaml(
-              "---",
-              """
-                ---
-                type: specs.openrewrite.org/v1beta/example
-                recipeName: org.openrewrite.java.OrderImports
-                examples:
-                - description: ''
-                  parameters:
-                  - 'null'
-                  sources:
-                  - before: |
-                      import java.util.List;
-                      class A {
-                      }
-                    after: |
-                      class A {
-                      }
-                    language: java
-                \n""",
-              spec -> spec.path("src/main/resources/META-INF/rewrite/examples.yml")
+            srcMainResources(
+              yaml(
+                "---",
+                """
+                  ---
+                  type: specs.openrewrite.org/v1beta/example
+                  recipeName: org.openrewrite.java.OrderImports
+                  examples:
+                  - description: ''
+                    parameters:
+                    - 'null'
+                    sources:
+                    - before: |
+                        import java.util.List;
+                        class A {
+                        }
+                      after: |
+                        class A {
+                        }
+                      language: java
+                  \n""",
+                spec -> spec.path("META-INF/rewrite/examples.yml")
+              )
             ),
             //language=java
             srcTestJava(
@@ -1341,25 +1341,27 @@ class ExamplesExtractorTest implements RewriteTest {
           mavenProject(
             "projectB",
             //language=yaml
-            yaml(
-              "---",
-              """
-                ---
-                type: specs.openrewrite.org/v1beta/example
-                recipeName: org.openrewrite.java.RemoveUnusedImports
-                examples:
-                - description: ''
-                  sources:
-                  - before: |
-                      import java.util.List;
-                      class B {
-                      }
-                    after: |
-                      class B {
-                      }
-                    language: java
-                \n""",
-              spec -> spec.path("src/main/resources/META-INF/rewrite/examples.yml")
+            srcMainResources(
+              yaml(
+                "---",
+                """
+                  ---
+                  type: specs.openrewrite.org/v1beta/example
+                  recipeName: org.openrewrite.java.RemoveUnusedImports
+                  examples:
+                  - description: ''
+                    sources:
+                    - before: |
+                        import java.util.List;
+                        class B {
+                        }
+                      after: |
+                        class B {
+                        }
+                      language: java
+                  \n""",
+                spec -> spec.path("META-INF/rewrite/examples.yml")
+              )
             ),
             //language=java
             srcTestJava(

--- a/src/test/java/org/openrewrite/java/recipes/ExamplesExtractorTest.java
+++ b/src/test/java/org/openrewrite/java/recipes/ExamplesExtractorTest.java
@@ -74,7 +74,6 @@ class ExamplesExtractorTest implements RewriteTest {
                   package org.openrewrite.staticanalysis;
 
                   import org.junit.jupiter.api.Test;
-                  import org.openrewrite.Recipe;
                   import org.openrewrite.DocumentExample;
                   import org.openrewrite.test.RecipeSpec;
                   import org.openrewrite.test.RewriteTest;
@@ -84,8 +83,7 @@ class ExamplesExtractorTest implements RewriteTest {
                   class ChainStringBuilderAppendCallsTest implements RewriteTest {
                       @Override
                       public void defaults(RecipeSpec spec) {
-                          Recipe recipe = new ChainStringBuilderAppendCalls();
-                          spec.recipe(recipe);
+                          spec.recipe(new ChainStringBuilderAppendCalls());
                       }
 
                       @DocumentExample(value = "Objects concatenation.")
@@ -952,7 +950,6 @@ class ExamplesExtractorTest implements RewriteTest {
                 package org.openrewrite.staticanalysis;
 
                 import org.junit.jupiter.api.Test;
-                import org.openrewrite.Recipe;
                 import org.openrewrite.DocumentExample;
                 import org.openrewrite.java.OrderImports;
                 import org.openrewrite.test.RecipeSpec;
@@ -992,7 +989,6 @@ class ExamplesExtractorTest implements RewriteTest {
                 package org.openrewrite.staticanalysis;
 
                 import org.junit.jupiter.api.Test;
-                import org.openrewrite.Recipe;
                 import org.openrewrite.DocumentExample;
                 import org.openrewrite.java.RemoveUnusedImports;
                 import org.openrewrite.test.RecipeSpec;
@@ -1072,7 +1068,6 @@ class ExamplesExtractorTest implements RewriteTest {
                 package org.openrewrite.staticanalysis;
 
                 import org.junit.jupiter.api.Test;
-                import org.openrewrite.Recipe;
                 import org.openrewrite.DocumentExample;
                 import org.openrewrite.java.OrderImports;
                 import org.openrewrite.test.RecipeSpec;
@@ -1122,7 +1117,7 @@ class ExamplesExtractorTest implements RewriteTest {
     }
 
     @Test
-    void twoProjectsWrittenToSeparateFiles() {
+    void twoProjectsWrittenToSeparateNewFiles() {
         //language=yaml
         rewriteRun(
           mavenProject(
@@ -1155,7 +1150,6 @@ class ExamplesExtractorTest implements RewriteTest {
                 package org.openrewrite.staticanalysis;
 
                 import org.junit.jupiter.api.Test;
-                import org.openrewrite.Recipe;
                 import org.openrewrite.DocumentExample;
                 import org.openrewrite.java.OrderImports;
                 import org.openrewrite.test.RecipeSpec;
@@ -1219,7 +1213,6 @@ class ExamplesExtractorTest implements RewriteTest {
                 package org.openrewrite.staticanalysis;
 
                 import org.junit.jupiter.api.Test;
-                import org.openrewrite.Recipe;
                 import org.openrewrite.DocumentExample;
                 import org.openrewrite.java.RemoveUnusedImports;
                 import org.openrewrite.test.RecipeSpec;
@@ -1237,6 +1230,130 @@ class ExamplesExtractorTest implements RewriteTest {
                     @Test
                     void removeUnusedImports() {
                         rewriteRun(
+                          java(
+                            \"""
+                              import java.util.List;
+                              class B {
+                              }
+                              \""",
+                            \"""
+                              class B {
+                              }
+                              \"""
+                          )
+                        );
+                    }
+                }
+                """
+            )
+          )
+        );
+    }
+
+    @Test
+    void twoProjectsWrittenToSeparateExistingFiles() {
+        //language=yaml
+        rewriteRun(
+          mavenProject(
+            "projectA",
+            yaml(
+              "---",
+              """
+                ---
+                type: specs.openrewrite.org/v1beta/example
+                recipeName: org.openrewrite.java.OrderImports
+                examples:
+                - description: ''
+                  parameters:
+                  - 'null'
+                  sources:
+                  - before: |
+                      import java.util.List;
+                      class A {
+                      }
+                    after: |
+                      class A {
+                      }
+                    language: java
+                \n""",
+              spec -> spec.path("/projectA/src/main/resources/META-INF/rewrite/examples.yml")
+            ),
+            //language=java
+            java(
+              """
+                package org.openrewrite.staticanalysis;
+
+                import org.junit.jupiter.api.Test;
+                import org.openrewrite.DocumentExample;
+                import org.openrewrite.java.OrderImports;
+                import org.openrewrite.test.RewriteTest;
+
+                import static org.openrewrite.java.Assertions.java;
+
+                class OrderImportsTest implements RewriteTest {
+                    @DocumentExample
+                    @Test
+                    void orderImports() {
+                        rewriteRun(
+                          spec -> spec.recipe(new OrderImports(null)),
+                          java(
+                            ""\"
+                              import java.util.List;
+                              class A {
+                              }
+                              ""\",
+                            ""\"
+                              class A {
+                              }
+                              ""\"
+                          )
+                        );
+                    }
+                }
+                """
+            )
+          ),
+          mavenProject(
+            "projectB",
+            //language=yaml
+            yaml(
+              "---",
+              """
+                ---
+                type: specs.openrewrite.org/v1beta/example
+                recipeName: org.openrewrite.java.RemoveUnusedImports
+                examples:
+                - description: ''
+                  sources:
+                  - before: |
+                      import java.util.List;
+                      class B {
+                      }
+                    after: |
+                      class B {
+                      }
+                    language: java
+                \n""",
+              spec -> spec.path("/projectB/src/main/resources/META-INF/rewrite/examples.yml")
+            ),
+            //language=java
+            java(
+              """
+                package org.openrewrite.staticanalysis;
+
+                import org.junit.jupiter.api.Test;
+                import org.openrewrite.DocumentExample;
+                import org.openrewrite.java.RemoveUnusedImports;
+                import org.openrewrite.test.RewriteTest;
+
+                import static org.openrewrite.java.Assertions.java;
+
+                class RemoveUnusedImportsTest implements RewriteTest {
+                    @DocumentExample
+                    @Test
+                    void removeUnusedImports() {
+                        rewriteRun(
+                          spec -> spec.recipe(new RemoveUnusedImports()),
                           java(
                             \"""
                               import java.util.List;


### PR DESCRIPTION
## What's changed?
Source sets were not taken into account correctly, so we saw files produced at incorrect paths.