### PR TITLE
Replace `null` with `doesNotExist()` in `RewriteTest`

### DIFF
--- a/src/main/java/org/openrewrite/java/recipes/ReplaceNullWithDoesNotExist.java
+++ b/src/main/java/org/openrewrite/java/recipes/ReplaceNullWithDoesNotExist.java
@@ -17,7 +17,10 @@ package org.openrewrite.java.recipes;
 
 import org.openrewrite.*;
 import org.openrewrite.internal.ListUtils;
-import org.openrewrite.java.*;
+import org.openrewrite.java.JavaIsoVisitor;
+import org.openrewrite.java.JavaParser;
+import org.openrewrite.java.JavaTemplate;
+import org.openrewrite.java.MethodMatcher;
 import org.openrewrite.java.search.UsesMethod;
 import org.openrewrite.java.tree.J;
 
@@ -41,11 +44,9 @@ public class ReplaceNullWithDoesNotExist extends Recipe {
         return Preconditions.check(
                 new UsesMethod<>(ASSERTIONS_MATCHER),
                 new JavaIsoVisitor<ExecutionContext>() {
-
                     @Override
                     public J.MethodInvocation visitMethodInvocation(J.MethodInvocation method, ExecutionContext ctx) {
                         J.MethodInvocation mi = super.visitMethodInvocation(method, ctx);
-
                         if (ASSERTIONS_MATCHER.matches(mi)) {
                             return mi.withArguments(ListUtils.map(method.getArguments(), (index, arg) -> {
                                 if (J.Literal.isLiteralValue(arg, null) && (index == 0 || index == 1)) {
@@ -66,11 +67,8 @@ public class ReplaceNullWithDoesNotExist extends Recipe {
                                 return arg;
                             }));
                         }
-
                         return mi;
-
                     }
-
                 }
         );
     }

--- a/src/main/java/org/openrewrite/java/recipes/ReplaceNullWithDoesNotExist.java
+++ b/src/main/java/org/openrewrite/java/recipes/ReplaceNullWithDoesNotExist.java
@@ -50,7 +50,7 @@ public class ReplaceNullWithDoesNotExist extends Recipe {
                         if (ASSERTIONS_MATCHER.matches(mi)) {
                             return mi.withArguments(ListUtils.map(method.getArguments(), (index, arg) -> {
                                 if (J.Literal.isLiteralValue(arg, null) && (index == 0 || index == 1)) {
-                                    return JavaTemplate.builder("doesNotExist()")
+                                    J.MethodInvocation doesNotExist = JavaTemplate.builder("doesNotExist()")
                                             .contextSensitive()
                                             .javaParser(JavaParser.fromJavaVersion().dependsOn(
                                                     "package org.openrewrite.test;\n" +
@@ -61,8 +61,8 @@ public class ReplaceNullWithDoesNotExist extends Recipe {
                                                             "}"
                                             ))
                                             .build()
-                                            .apply(new Cursor(getCursor(), arg), arg.getCoordinates().replace())
-                                            .withPrefix(arg.getPrefix());
+                                            .apply(new Cursor(getCursor(), arg), arg.getCoordinates().replace());
+                                    return doesNotExist.withPrefix(arg.getPrefix());
                                 }
                                 return arg;
                             }));

--- a/src/main/java/org/openrewrite/java/recipes/ReplaceNullWithDoesNotExist.java
+++ b/src/main/java/org/openrewrite/java/recipes/ReplaceNullWithDoesNotExist.java
@@ -1,0 +1,122 @@
+/*
+ * Copyright 2025 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.java.recipes;
+
+import org.openrewrite.ExecutionContext;
+import org.openrewrite.Preconditions;
+import org.openrewrite.Recipe;
+import org.openrewrite.TreeVisitor;
+import org.openrewrite.java.JavaIsoVisitor;
+import org.openrewrite.java.JavaParser;
+import org.openrewrite.java.JavaTemplate;
+import org.openrewrite.java.MethodMatcher;
+import org.openrewrite.java.search.UsesMethod;
+import org.openrewrite.java.tree.J;
+import org.openrewrite.java.tree.JavaType;
+import org.openrewrite.java.tree.Expression;
+import org.openrewrite.java.tree.Flag;
+
+import java.util.List;
+
+public class ReplaceNullWithDoesNotExist extends Recipe {
+
+    @Override
+    public String getDisplayName() {
+        return "Replace null with RewriteTest.doesNotExist()";
+    }
+
+    @Override
+    public String getDescription() {
+        return "Replace the first or second `null` argument in OpenRewrite Assertions class methods with `RewriteTest.doesNotExist()`.";
+    }
+
+    @Override
+    public TreeVisitor<?, ExecutionContext> getVisitor() {
+        return Preconditions.check(
+                new UsesMethod<>("org.openrewrite.*.Assertions *(..)"),
+                new JavaIsoVisitor<ExecutionContext>() {
+                    // Match any static method from Assertions classes
+                    private final MethodMatcher assertionsMatcher = new MethodMatcher("org.openrewrite.*.Assertions *(..)");
+
+                    private final JavaTemplate doesNotExistTemplate = JavaTemplate.builder("doesNotExist()")
+                            .contextSensitive()
+                            .staticImports("org.openrewrite.test.RewriteTest.doesNotExist")
+                            .build();
+
+                    @Override
+                    public J.MethodInvocation visitMethodInvocation(J.MethodInvocation method, ExecutionContext ctx) {
+                        J.MethodInvocation mi = super.visitMethodInvocation(method, ctx);
+
+                        // Check if this is a call to an Assertions method
+                        if (!assertionsMatcher.matches(mi)) {
+                            return mi;
+                        }
+
+                        // Check if the method is a static method from an Assertions class
+                        JavaType.Method methodType = mi.getMethodType();
+                        if (methodType == null || !methodType.getFlags().contains(Flag.Static) ||
+                            !methodType.getDeclaringType().getFullyQualifiedName().matches("org\\.openrewrite\\.\\w+\\.Assertions")) {
+                            return mi;
+                        }
+
+                        List<Expression> args = mi.getArguments();
+                        if (args.isEmpty()) {
+                            return mi;
+                        }
+
+                        boolean modified = false;
+
+                        // Check first argument
+                        if (isNullLiteral(args.get(0))) {
+                            mi = mi.withArguments(replaceArgument(mi, 0, ctx));
+                            modified = true;
+                        }
+
+                        // Check second argument if first wasn't null
+                        if (!modified && args.size() >= 2 && isNullLiteral(args.get(1))) {
+                            mi = mi.withArguments(replaceArgument(mi, 1, ctx));
+                            modified = true;
+                        }
+
+                        if (modified) {
+                            maybeAddImport("org.openrewrite.test.RewriteTest");
+                        }
+
+                        return mi;
+                    }
+
+                    private boolean isNullLiteral(Expression expr) {
+                        return expr instanceof J.Literal && ((J.Literal) expr).getValue() == null;
+                    }
+
+                    private List<Expression> replaceArgument(J.MethodInvocation method, int index, ExecutionContext ctx) {
+                        List<Expression> args = method.getArguments();
+                        Expression nullArg = args.get(index);
+                        Expression replacement = doesNotExistTemplate.apply(getCursor(), nullArg.getCoordinates().replace())
+                                .withPrefix(nullArg.getPrefix());
+
+                        return replaceAtIndex(args, index, replacement);
+                    }
+
+                    private List<Expression> replaceAtIndex(List<Expression> list, int index, Expression replacement) {
+                        List<Expression> newList = new java.util.ArrayList<>(list);
+                        newList.set(index, replacement);
+                        return newList;
+                    }
+                }
+        );
+    }
+}

--- a/src/main/resources/META-INF/rewrite/recipebestpractice.yml
+++ b/src/main/resources/META-INF/rewrite/recipebestpractice.yml
@@ -79,6 +79,7 @@ recipeList:
   - org.openrewrite.java.recipes.SelectRecipeExamples
   - org.openrewrite.java.recipes.SingleDocumentExample
   - org.openrewrite.java.recipes.ReorderTestMethods
+  - org.openrewrite.java.recipes.ReplaceNullWithDoesNotExist
   - org.openrewrite.java.recipes.SourceSpecTextBlockNewLine
   - org.openrewrite.java.recipes.SourceSpecTextBlockIndentation
   - org.openrewrite.java.testing.cleanup.RemoveTestPrefix

--- a/src/test/java/org/openrewrite/java/recipes/ExamplesExtractorTest.java
+++ b/src/test/java/org/openrewrite/java/recipes/ExamplesExtractorTest.java
@@ -121,7 +121,7 @@ class ExamplesExtractorTest implements RewriteTest {
             ),
             //language=yaml
             yaml(
-              null, // newly created
+              doesNotExist(), // newly created
               """
                 ---
                 type: specs.openrewrite.org/v1beta/example
@@ -310,7 +310,7 @@ class ExamplesExtractorTest implements RewriteTest {
             ),
             //language=yaml
             yaml(
-              null,
+              doesNotExist(),
               """
                 ---
                 type: specs.openrewrite.org/v1beta/example
@@ -400,7 +400,7 @@ class ExamplesExtractorTest implements RewriteTest {
             ),
             //language=yaml
             yaml(
-              null,
+              doesNotExist(),
               """
                 ---
                 type: specs.openrewrite.org/v1beta/example
@@ -581,7 +581,7 @@ class ExamplesExtractorTest implements RewriteTest {
             ),
             //language=yaml
             yaml(
-              null,
+              doesNotExist(),
               """
                 ---
                 type: specs.openrewrite.org/v1beta/example
@@ -708,7 +708,7 @@ class ExamplesExtractorTest implements RewriteTest {
             ),
             //language=yaml
             yaml(
-              null, """
+              doesNotExist(), """
                 ---
                 type: specs.openrewrite.org/v1beta/example
                 recipeName: org.openrewrite.java.migrate.net.JavaNetAPIs
@@ -783,7 +783,7 @@ class ExamplesExtractorTest implements RewriteTest {
             ),
             //language=yaml
             yaml(
-              null, """
+              doesNotExist(), """
                 ---
                 type: specs.openrewrite.org/v1beta/example
                 recipeName: org.openrewrite.java.migrate.net.JavaNetAPIs
@@ -868,7 +868,7 @@ class ExamplesExtractorTest implements RewriteTest {
             ),
             //language=yaml
             yaml(
-              null,
+              doesNotExist(),
               """
                 ---
                 type: specs.openrewrite.org/v1beta/example
@@ -921,7 +921,7 @@ class ExamplesExtractorTest implements RewriteTest {
             //language=yaml
             srcMainResources(
               yaml(
-                null, // newly created
+                doesNotExist(), // newly created
                 """
                   ---
                   type: specs.openrewrite.org/v1beta/example
@@ -1048,7 +1048,7 @@ class ExamplesExtractorTest implements RewriteTest {
             "project",
             srcMainResources(
               yaml(
-                null, // newly created
+                doesNotExist(), // newly created
                 """
                   ---
                   type: specs.openrewrite.org/v1beta/example
@@ -1142,7 +1142,7 @@ class ExamplesExtractorTest implements RewriteTest {
             "projectA",
             srcMainResources(
               yaml(
-                null, // newly created
+                doesNotExist(), // newly created
                 """
                   ---
                   type: specs.openrewrite.org/v1beta/example
@@ -1211,7 +1211,7 @@ class ExamplesExtractorTest implements RewriteTest {
             //language=yaml
             srcMainResources(
               yaml(
-                null, // newly created
+                doesNotExist(), // newly created
                 """
                   ---
                   type: specs.openrewrite.org/v1beta/example

--- a/src/test/java/org/openrewrite/java/recipes/ReplaceNullWithDoesNotExistTest.java
+++ b/src/test/java/org/openrewrite/java/recipes/ReplaceNullWithDoesNotExistTest.java
@@ -37,20 +37,20 @@ class ReplaceNullWithDoesNotExistTest implements RewriteTest {
         rewriteRun(
           java(
             """
+              import org.openrewrite.test.RewriteTest;
               import static org.openrewrite.java.Assertions.java;
 
-              class Test {
+              class Test implements RewriteTest {
                   void test() {
                       java(null, "after content");
                   }
               }
               """,
             """
+              import org.openrewrite.test.RewriteTest;
               import static org.openrewrite.java.Assertions.java;
 
-              import static org.openrewrite.test.RewriteTest.doesNotExist;
-
-              class Test {
+              class Test implements RewriteTest {
                   void test() {
                       java(doesNotExist(), "after content");
                   }
@@ -65,19 +65,20 @@ class ReplaceNullWithDoesNotExistTest implements RewriteTest {
         rewriteRun(
           java(
             """
+              import org.openrewrite.test.RewriteTest;
               import static org.openrewrite.java.Assertions.java;
 
-              class Test {
+              class Test implements RewriteTest {
                   void test() {
                       java("before content", null);
                   }
               }
               """,
             """
+              import org.openrewrite.test.RewriteTest;
               import static org.openrewrite.java.Assertions.java;
-              import static org.openrewrite.test.RewriteTest.doesNotExist;
 
-              class Test {
+              class Test implements RewriteTest {
                   void test() {
                       java("before content", doesNotExist());
                   }
@@ -92,19 +93,20 @@ class ReplaceNullWithDoesNotExistTest implements RewriteTest {
         rewriteRun(
           java(
             """
+              import org.openrewrite.test.RewriteTest;
               import static org.openrewrite.java.Assertions.java;
 
-              class Test {
+              class Test implements RewriteTest {
                   void test() {
                       java(null, null);
                   }
               }
               """,
             """
+              import org.openrewrite.test.RewriteTest;
               import static org.openrewrite.java.Assertions.java;
-              import static org.openrewrite.test.RewriteTest.doesNotExist;
 
-              class Test {
+              class Test implements RewriteTest {
                   void test() {
                       java(doesNotExist(), null);
                   }
@@ -119,19 +121,20 @@ class ReplaceNullWithDoesNotExistTest implements RewriteTest {
         rewriteRun(
           java(
             """
+              import org.openrewrite.test.RewriteTest;
               import static org.openrewrite.yaml.Assertions.yaml;
 
-              class Test {
+              class Test implements RewriteTest {
                   void test() {
                       yaml(null, "content: value");
                   }
               }
               """,
             """
-              import static org.openrewrite.test.RewriteTest.doesNotExist;
+              import org.openrewrite.test.RewriteTest;
               import static org.openrewrite.yaml.Assertions.yaml;
 
-              class Test {
+              class Test implements RewriteTest {
                   void test() {
                       yaml(doesNotExist(), "content: value");
                   }
@@ -146,9 +149,10 @@ class ReplaceNullWithDoesNotExistTest implements RewriteTest {
         rewriteRun(
           java(
             """
+              import org.openrewrite.test.RewriteTest;
               import static org.openrewrite.java.Assertions.java;
 
-              class Test {
+              class Test implements RewriteTest {
                   void test() {
                       java(null, "after", spec -> spec.path("Test.java"));
                   }
@@ -156,9 +160,8 @@ class ReplaceNullWithDoesNotExistTest implements RewriteTest {
               """,
             """
               import static org.openrewrite.java.Assertions.java;
-              import static org.openrewrite.test.RewriteTest.doesNotExist;
 
-              class Test {
+              class Test implements RewriteTest {
                   void test() {
                       java(doesNotExist(), "after", spec -> spec.path("Test.java"));
                   }
@@ -173,9 +176,10 @@ class ReplaceNullWithDoesNotExistTest implements RewriteTest {
         rewriteRun(
           java(
             """
+              import org.openrewrite.test.RewriteTest;
               import static org.openrewrite.java.Assertions.java;
 
-              class Test {
+              class Test implements RewriteTest {
                   void test() {
                       java("before", "after");
                       java("single argument");
@@ -191,7 +195,8 @@ class ReplaceNullWithDoesNotExistTest implements RewriteTest {
         rewriteRun(
           java(
             """
-              class Test {
+              import org.openrewrite.test.RewriteTest;
+              class Test implements RewriteTest {
                   void test() {
                       someMethod(null, null);
                       String.valueOf(null);
@@ -210,10 +215,11 @@ class ReplaceNullWithDoesNotExistTest implements RewriteTest {
         rewriteRun(
           java(
             """
+              import org.openrewrite.test.RewriteTest;
               import static org.openrewrite.java.Assertions.java;
               import static org.openrewrite.java.Assertions.srcMainJava;
 
-              class Test {
+              class Test implements RewriteTest {
                   void test() {
                       rewriteRun(
                           java(null, "after"),
@@ -226,11 +232,11 @@ class ReplaceNullWithDoesNotExistTest implements RewriteTest {
               }
               """,
             """
+              import org.openrewrite.test.RewriteTest;
               import static org.openrewrite.java.Assertions.java;
               import static org.openrewrite.java.Assertions.srcMainJava;
-              import static org.openrewrite.test.RewriteTest.doesNotExist;
 
-              class Test {
+              class Test implements RewriteTest {
                   void test() {
                       rewriteRun(
                           java(doesNotExist(), "after"),
@@ -251,9 +257,10 @@ class ReplaceNullWithDoesNotExistTest implements RewriteTest {
         rewriteRun(
           java(
             """
+              import org.openrewrite.test.RewriteTest;
               import static org.openrewrite.java.Assertions.java;
 
-              class Test {
+              class Test implements RewriteTest {
                   void test() {
                       java(
                           null,
@@ -266,10 +273,10 @@ class ReplaceNullWithDoesNotExistTest implements RewriteTest {
               }
               """,
             """
+              import org.openrewrite.test.RewriteTest;
               import static org.openrewrite.java.Assertions.java;
-              import static org.openrewrite.test.RewriteTest.doesNotExist;
 
-              class Test {
+              class Test implements RewriteTest {
                   void test() {
                       java(
                           doesNotExist(),
@@ -290,16 +297,16 @@ class ReplaceNullWithDoesNotExistTest implements RewriteTest {
         rewriteRun(
           java(
             """
-              class Test {
+              import org.openrewrite.test.RewriteTest;
+              class Test implements RewriteTest {
                   void test() {
                       org.openrewrite.java.Assertions.java(null, "after");
                   }
               }
               """,
             """
-              import static org.openrewrite.test.RewriteTest.doesNotExist;
-
-              class Test {
+              import org.openrewrite.test.RewriteTest;
+              class Test implements RewriteTest {
                   void test() {
                       org.openrewrite.java.Assertions.java(doesNotExist(), "after");
                   }

--- a/src/test/java/org/openrewrite/java/recipes/ReplaceNullWithDoesNotExistTest.java
+++ b/src/test/java/org/openrewrite/java/recipes/ReplaceNullWithDoesNotExistTest.java
@@ -108,7 +108,7 @@ class ReplaceNullWithDoesNotExistTest implements RewriteTest {
 
               class Test implements RewriteTest {
                   void test() {
-                      java(doesNotExist(), null);
+                      java(doesNotExist(), doesNotExist());
                   }
               }
               """
@@ -159,6 +159,7 @@ class ReplaceNullWithDoesNotExistTest implements RewriteTest {
               }
               """,
             """
+              import org.openrewrite.test.RewriteTest;
               import static org.openrewrite.java.Assertions.java;
 
               class Test implements RewriteTest {
@@ -203,48 +204,6 @@ class ReplaceNullWithDoesNotExistTest implements RewriteTest {
                   }
 
                   void someMethod(Object a, Object b) {
-                  }
-              }
-              """
-          )
-        );
-    }
-
-    @Test
-    void handleNullInNestedCalls() {
-        rewriteRun(
-          java(
-            """
-              import org.openrewrite.test.RewriteTest;
-              import static org.openrewrite.java.Assertions.java;
-              import static org.openrewrite.java.Assertions.srcMainJava;
-
-              class Test implements RewriteTest {
-                  void test() {
-                      rewriteRun(
-                          java(null, "after"),
-                          srcMainJava(null, "after")
-                      );
-                  }
-
-                  void rewriteRun(Object... sources) {
-                  }
-              }
-              """,
-            """
-              import org.openrewrite.test.RewriteTest;
-              import static org.openrewrite.java.Assertions.java;
-              import static org.openrewrite.java.Assertions.srcMainJava;
-
-              class Test implements RewriteTest {
-                  void test() {
-                      rewriteRun(
-                          java(doesNotExist(), "after"),
-                          srcMainJava(doesNotExist(), "after")
-                      );
-                  }
-
-                  void rewriteRun(Object... sources) {
                   }
               }
               """

--- a/src/test/java/org/openrewrite/java/recipes/ReplaceNullWithDoesNotExistTest.java
+++ b/src/test/java/org/openrewrite/java/recipes/ReplaceNullWithDoesNotExistTest.java
@@ -1,0 +1,317 @@
+/*
+ * Copyright 2025 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.java.recipes;
+
+import org.junit.jupiter.api.Test;
+import org.openrewrite.DocumentExample;
+import org.openrewrite.java.JavaParser;
+import org.openrewrite.test.RecipeSpec;
+import org.openrewrite.test.RewriteTest;
+
+import static org.openrewrite.java.Assertions.java;
+
+class ReplaceNullWithDoesNotExistTest implements RewriteTest {
+
+    @Override
+    public void defaults(RecipeSpec spec) {
+        spec.recipe(new ReplaceNullWithDoesNotExist())
+          .parser(JavaParser.fromJavaVersion().classpath(JavaParser.runtimeClasspath()));
+    }
+
+    @Test
+    @DocumentExample
+    void replaceFirstNullArgument() {
+        rewriteRun(
+          java(
+            """
+              import static org.openrewrite.java.Assertions.java;
+
+              class Test {
+                  void test() {
+                      java(null, "after content");
+                  }
+              }
+              """,
+            """
+              import static org.openrewrite.java.Assertions.java;
+
+              import org.openrewrite.test.RewriteTest;
+
+              class Test {
+                  void test() {
+                      java(RewriteTest.doesNotExist(), "after content");
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void replaceSecondNullArgument() {
+        rewriteRun(
+          java(
+            """
+              import static org.openrewrite.java.Assertions.java;
+
+              class Test {
+                  void test() {
+                      java("before content", null);
+                  }
+              }
+              """,
+            """
+              import static org.openrewrite.java.Assertions.java;
+
+              import org.openrewrite.test.RewriteTest;
+
+              class Test {
+                  void test() {
+                      java("before content", RewriteTest.doesNotExist());
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void replaceOnlyFirstNullWhenBothAreNull() {
+        rewriteRun(
+          java(
+            """
+              import static org.openrewrite.java.Assertions.java;
+
+              class Test {
+                  void test() {
+                      java(null, null);
+                  }
+              }
+              """,
+            """
+              import static org.openrewrite.java.Assertions.java;
+
+              import org.openrewrite.test.RewriteTest;
+
+              class Test {
+                  void test() {
+                      java(RewriteTest.doesNotExist(), null);
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void handleYamlAssertions() {
+        rewriteRun(
+          java(
+            """
+              import static org.openrewrite.yaml.Assertions.yaml;
+
+              class Test {
+                  void test() {
+                      yaml(null, "content: value");
+                  }
+              }
+              """,
+            """
+              import static org.openrewrite.yaml.Assertions.yaml;
+
+              import org.openrewrite.test.RewriteTest;
+
+              class Test {
+                  void test() {
+                      yaml(RewriteTest.doesNotExist(), "content: value");
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void handleThreeArgumentMethods() {
+        rewriteRun(
+          java(
+            """
+              import static org.openrewrite.java.Assertions.java;
+
+              class Test {
+                  void test() {
+                      java(null, "after", spec -> spec.path("Test.java"));
+                  }
+              }
+              """,
+            """
+              import static org.openrewrite.java.Assertions.java;
+
+              import org.openrewrite.test.RewriteTest;
+
+              class Test {
+                  void test() {
+                      java(RewriteTest.doesNotExist(), "after", spec -> spec.path("Test.java"));
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void doNotChangeNonNullArguments() {
+        rewriteRun(
+          java(
+            """
+              import static org.openrewrite.java.Assertions.java;
+
+              class Test {
+                  void test() {
+                      java("before", "after");
+                      java("single argument");
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void doNotChangeNullInNonAssertionMethods() {
+        rewriteRun(
+          java(
+            """
+              class Test {
+                  void test() {
+                      someMethod(null, null);
+                      String.valueOf(null);
+                  }
+
+                  void someMethod(Object a, Object b) {
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void handleNullInNestedCalls() {
+        rewriteRun(
+          java(
+            """
+              import static org.openrewrite.java.Assertions.java;
+              import static org.openrewrite.java.Assertions.srcMainJava;
+
+              class Test {
+                  void test() {
+                      rewriteRun(
+                          java(null, "after"),
+                          srcMainJava(null, "after")
+                      );
+                  }
+
+                  void rewriteRun(Object... sources) {
+                  }
+              }
+              """,
+            """
+              import static org.openrewrite.java.Assertions.java;
+              import static org.openrewrite.java.Assertions.srcMainJava;
+
+              import org.openrewrite.test.RewriteTest;
+
+              class Test {
+                  void test() {
+                      rewriteRun(
+                          java(RewriteTest.doesNotExist(), "after"),
+                          srcMainJava(RewriteTest.doesNotExist(), "after")
+                      );
+                  }
+
+                  void rewriteRun(Object... sources) {
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void preserveFormatting() {
+        rewriteRun(
+          java(
+            """
+              import static org.openrewrite.java.Assertions.java;
+
+              class Test {
+                  void test() {
+                      java(
+                          null,
+                          \"\"\"
+                          public class Foo {
+                          }
+                          \"\"\"
+                      );
+                  }
+              }
+              """,
+            """
+              import static org.openrewrite.java.Assertions.java;
+
+              import org.openrewrite.test.RewriteTest;
+
+              class Test {
+                  void test() {
+                      java(
+                          RewriteTest.doesNotExist(),
+                          \"\"\"
+                          public class Foo {
+                          }
+                          \"\"\"
+                      );
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void handleFullyQualifiedAssertionCalls() {
+        rewriteRun(
+          java(
+            """
+              class Test {
+                  void test() {
+                      org.openrewrite.java.Assertions.java(null, "after");
+                  }
+              }
+              """,
+            """
+              import org.openrewrite.test.RewriteTest;
+
+              class Test {
+                  void test() {
+                      org.openrewrite.java.Assertions.java(RewriteTest.doesNotExist(), "after");
+                  }
+              }
+              """
+          )
+        );
+    }
+}

--- a/src/test/java/org/openrewrite/java/recipes/ReplaceNullWithDoesNotExistTest.java
+++ b/src/test/java/org/openrewrite/java/recipes/ReplaceNullWithDoesNotExistTest.java
@@ -31,8 +31,8 @@ class ReplaceNullWithDoesNotExistTest implements RewriteTest {
           .parser(JavaParser.fromJavaVersion().classpath(JavaParser.runtimeClasspath()));
     }
 
-    @Test
     @DocumentExample
+    @Test
     void replaceFirstNullArgument() {
         rewriteRun(
           java(
@@ -48,11 +48,11 @@ class ReplaceNullWithDoesNotExistTest implements RewriteTest {
             """
               import static org.openrewrite.java.Assertions.java;
 
-              import org.openrewrite.test.RewriteTest;
+              import static org.openrewrite.test.RewriteTest.doesNotExist;
 
               class Test {
                   void test() {
-                      java(RewriteTest.doesNotExist(), "after content");
+                      java(doesNotExist(), "after content");
                   }
               }
               """
@@ -75,12 +75,11 @@ class ReplaceNullWithDoesNotExistTest implements RewriteTest {
               """,
             """
               import static org.openrewrite.java.Assertions.java;
-
-              import org.openrewrite.test.RewriteTest;
+              import static org.openrewrite.test.RewriteTest.doesNotExist;
 
               class Test {
                   void test() {
-                      java("before content", RewriteTest.doesNotExist());
+                      java("before content", doesNotExist());
                   }
               }
               """
@@ -103,12 +102,11 @@ class ReplaceNullWithDoesNotExistTest implements RewriteTest {
               """,
             """
               import static org.openrewrite.java.Assertions.java;
-
-              import org.openrewrite.test.RewriteTest;
+              import static org.openrewrite.test.RewriteTest.doesNotExist;
 
               class Test {
                   void test() {
-                      java(RewriteTest.doesNotExist(), null);
+                      java(doesNotExist(), null);
                   }
               }
               """
@@ -130,13 +128,12 @@ class ReplaceNullWithDoesNotExistTest implements RewriteTest {
               }
               """,
             """
+              import static org.openrewrite.test.RewriteTest.doesNotExist;
               import static org.openrewrite.yaml.Assertions.yaml;
-
-              import org.openrewrite.test.RewriteTest;
 
               class Test {
                   void test() {
-                      yaml(RewriteTest.doesNotExist(), "content: value");
+                      yaml(doesNotExist(), "content: value");
                   }
               }
               """
@@ -159,12 +156,11 @@ class ReplaceNullWithDoesNotExistTest implements RewriteTest {
               """,
             """
               import static org.openrewrite.java.Assertions.java;
-
-              import org.openrewrite.test.RewriteTest;
+              import static org.openrewrite.test.RewriteTest.doesNotExist;
 
               class Test {
                   void test() {
-                      java(RewriteTest.doesNotExist(), "after", spec -> spec.path("Test.java"));
+                      java(doesNotExist(), "after", spec -> spec.path("Test.java"));
                   }
               }
               """
@@ -232,14 +228,13 @@ class ReplaceNullWithDoesNotExistTest implements RewriteTest {
             """
               import static org.openrewrite.java.Assertions.java;
               import static org.openrewrite.java.Assertions.srcMainJava;
-
-              import org.openrewrite.test.RewriteTest;
+              import static org.openrewrite.test.RewriteTest.doesNotExist;
 
               class Test {
                   void test() {
                       rewriteRun(
-                          java(RewriteTest.doesNotExist(), "after"),
-                          srcMainJava(RewriteTest.doesNotExist(), "after")
+                          java(doesNotExist(), "after"),
+                          srcMainJava(doesNotExist(), "after")
                       );
                   }
 
@@ -272,13 +267,12 @@ class ReplaceNullWithDoesNotExistTest implements RewriteTest {
               """,
             """
               import static org.openrewrite.java.Assertions.java;
-
-              import org.openrewrite.test.RewriteTest;
+              import static org.openrewrite.test.RewriteTest.doesNotExist;
 
               class Test {
                   void test() {
                       java(
-                          RewriteTest.doesNotExist(),
+                          doesNotExist(),
                           \"\"\"
                           public class Foo {
                           }
@@ -303,11 +297,11 @@ class ReplaceNullWithDoesNotExistTest implements RewriteTest {
               }
               """,
             """
-              import org.openrewrite.test.RewriteTest;
+              import static org.openrewrite.test.RewriteTest.doesNotExist;
 
               class Test {
                   void test() {
-                      org.openrewrite.java.Assertions.java(RewriteTest.doesNotExist(), "after");
+                      org.openrewrite.java.Assertions.java(doesNotExist(), "after");
                   }
               }
               """


### PR DESCRIPTION
Make better use of the interface method to clearly indicate what's expected before/after a recipe run.