### PR TITLE
Fix typo in `RecipeNullabilityBestPractices`

### DIFF
--- a/src/main/resources/META-INF/rewrite/recipebestpractice.yml
+++ b/src/main/resources/META-INF/rewrite/recipebestpractice.yml
@@ -111,6 +111,6 @@ recipeList:
       annotationPattern: '@javax.annotation.Nonnull'
   - org.openrewrite.java.RemoveAnnotation:
       annotationPattern: '@jakarta.annotation.Nonnull'
-  - org.openrewrite.java.jspecify.MigrateToJspecify
+  - org.openrewrite.java.jspecify.MigrateToJSpecify
   - org.openrewrite.staticanalysis.AnnotateNullableMethods
   - org.openrewrite.staticanalysis.NullableOnMethodReturnType


### PR DESCRIPTION
<!--
Thank you for taking the time to contribute to OpenRewrite!
Feel free to delete any sections that don't apply to your pull request.
-->

## What's changed?
<!-- A brief description of the changes in this pull request -->
Fixed the name of the `org.openrewrite.java.jspecify.MigrateToJSpecify` recipe leading to warings in recipe execution.

## What's your motivation?
<!-- This can link to close a separate issue, or be described on the pull request itself -->
silence rewrite-recipe-starter

## Anything in particular you'd like reviewers to focus on?
<!-- You can also start a discussion on particular aspects of your implementation on the files tab yourself. -->
Shouldn't it be `org.openrewrite.java.jspecify.JSpecifyBestPractices` instead?

## Anyone you would like to review specifically?
<!-- @mention them here -->

## Have you considered any alternatives or workarounds?
<!-- Any other ways to solve the problem, or ways to work around the problem. -->

## Any additional context
<!-- Any thoughts you would like to share in addition to the above. -->

### Checklist
- [ ] I've added unit tests to cover both positive and negative cases
- [ ] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [ ] I've used the IntelliJ IDEA auto-formatter on affected files
