### PR TITLE
Removal of "RemoveTraitsUsageRecipes"

### DIFF
--- a/src/main/resources/META-INF/rewrite/recipebestpractice.yml
+++ b/src/main/resources/META-INF/rewrite/recipebestpractice.yml
@@ -67,7 +67,6 @@ recipeList:
   - org.openrewrite.java.recipes.NoMutableStaticFieldsInRecipes
   - org.openrewrite.java.recipes.RecipeEqualsAndHashCodeCallSuper
   - org.openrewrite.java.recipes.UseTreeRandomId
-  - org.openrewrite.java.recipes.migrate.RemoveTraitsUsageRecipes
   - org.openrewrite.staticanalysis.NeedBraces
   - org.openrewrite.staticanalysis.RemoveSystemOutPrintln
   - org.openrewrite.java.RemoveAnnotation:


### PR DESCRIPTION
## What's changed?
This change removes `RemoveTraitsUsageRecipes` as it is causing an error logged to console when the JavaBestPracticesRecipes set is used.

## What's your motivation?
Closes #32 when merged.

## Have you considered any alternatives or workarounds?
I looked to see if that recipe had moved or been renamed, but I couldn't find any current documentation on it, demonstrating that it's a legacy recipe.