### PR TITLE
Add data table to GenerateDeprecatedMethodRecipes

### DIFF
--- a/src/main/java/org/openrewrite/java/recipes/DeprecatedMethodDelegations.java
+++ b/src/main/java/org/openrewrite/java/recipes/DeprecatedMethodDelegations.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2025 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.java.recipes;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreType;
+import lombok.Value;
+import org.openrewrite.Column;
+import org.openrewrite.DataTable;
+import org.openrewrite.Recipe;
+
+@JsonIgnoreType
+public class DeprecatedMethodDelegations extends DataTable<DeprecatedMethodDelegations.Row> {
+
+    public DeprecatedMethodDelegations(Recipe recipe) {
+        super(recipe,
+                "Deprecated method delegations",
+                "Deprecated methods that delegate to another method in the same class, " +
+                        "suitable for inlining via `InlineMethodCalls`.");
+    }
+
+    @Value
+    public static class Row {
+        @Column(displayName = "Method pattern",
+                description = "The method pattern of the deprecated method.")
+        String methodPattern;
+
+        @Column(displayName = "Replacement",
+                description = "The replacement expression to inline.")
+        String replacement;
+
+        @Column(displayName = "Recipe YAML",
+                description = "A YAML snippet that can be copied into a recipe list.")
+        String recipeYaml;
+    }
+}

--- a/src/main/java/org/openrewrite/java/recipes/GenerateDeprecatedMethodRecipes.java
+++ b/src/main/java/org/openrewrite/java/recipes/GenerateDeprecatedMethodRecipes.java
@@ -39,6 +39,8 @@ import static java.util.Collections.emptyList;
 
 public class GenerateDeprecatedMethodRecipes extends ScanningRecipe<GenerateDeprecatedMethodRecipes.Accumulator> {
 
+    transient DeprecatedMethodDelegations dataTable = new DeprecatedMethodDelegations(this);
+
     private static final AnnotationMatcher DEPRECATED_MATCHER = new AnnotationMatcher("@java.lang.Deprecated");
     private static final AnnotationMatcher TO_BE_REMOVED_MATCHER = new AnnotationMatcher("@org.openrewrite.internal.ToBeRemoved");
     private static final Path OUTPUT_RELATIVE = Paths.get("src/main/resources/META-INF/rewrite/inline-deprecated-methods.yml");
@@ -123,12 +125,16 @@ public class GenerateDeprecatedMethodRecipes extends ScanningRecipe<GenerateDepr
 
                             String replacement = methodCall.printTrimmed(getCursor())
                                     .replaceAll("\\n\\s+", " ");
+                            String methodPattern = MethodMatcher.methodPattern(md.getMethodType());
                             acc.candidatesByProject
                                     .computeIfAbsent(javaProject, k -> new ArrayList<>())
-                                    .add(new MethodInlineCandidate(
-                                            MethodMatcher.methodPattern(md.getMethodType()),
-                                            replacement));
+                                    .add(new MethodInlineCandidate(methodPattern, replacement));
                             acc.projectBasePaths.putIfAbsent(javaProject, projectBase);
+                            dataTable.insertRow(ctx, new DeprecatedMethodDelegations.Row(
+                                    methodPattern, replacement,
+                                    "- org.openrewrite.java.InlineMethodCalls:\n" +
+                                            "    methodPattern: '" + methodPattern + "'\n" +
+                                            "    replacement: '" + replacement + "'"));
                             return md;
                         }
                     }.visit(tree, ctx);

--- a/src/test/java/org/openrewrite/java/recipes/GenerateDeprecatedMethodRecipesTest.java
+++ b/src/test/java/org/openrewrite/java/recipes/GenerateDeprecatedMethodRecipesTest.java
@@ -38,6 +38,51 @@ class GenerateDeprecatedMethodRecipesTest implements RewriteTest {
         spec.recipe(new GenerateDeprecatedMethodRecipes());
     }
 
+    @Test
+    void dataTable() {
+        rewriteRun(
+          spec -> spec.dataTable(DeprecatedMethodDelegations.Row.class, rows -> {
+              assertThat(rows).hasSize(1);
+              assertThat(rows.get(0).getMethodPattern()).isEqualTo("com.example.Bar oldMethod(java.lang.String)");
+              assertThat(rows.get(0).getReplacement()).isEqualTo("newMethod(s, \"default\")");
+              assertThat(rows.get(0).getRecipeYaml()).isEqualTo(
+                  "- org.openrewrite.java.InlineMethodCalls:\n" +
+                  "    methodPattern: 'com.example.Bar oldMethod(java.lang.String)'\n" +
+                  "    replacement: 'newMethod(s, \"default\")'");
+          }),
+          java(
+            """
+              package com.example;
+
+              public class Bar {
+                  public void newMethod(String s, String defaultVal) {
+                  }
+
+                  @Deprecated
+                  public void oldMethod(String s) {
+                      newMethod(s, "default");
+                  }
+              }
+              """
+          ),
+          yaml(
+            doesNotExist(),
+            //language=yaml
+            """
+              type: specs.openrewrite.org/v1beta/recipe
+              name: org.openrewrite.recipes.InlineDeprecatedMethods
+              displayName: Inline deprecated delegating methods
+              description: Automatically generated recipes to inline deprecated method calls that delegate to other methods in the same class.
+              recipeList:
+                - org.openrewrite.java.InlineMethodCalls:
+                    methodPattern: 'com.example.Bar oldMethod(java.lang.String)'
+                    replacement: 'newMethod(s, "default")'
+              """,
+            spec -> spec.path("src/main/resources/META-INF/rewrite/inline-deprecated-methods.yml")
+          )
+        );
+    }
+
     @DocumentExample
     @Test
     void constructorDelegation() {


### PR DESCRIPTION
## Summary
- Adds a `DeprecatedMethodDelegations` data table to `GenerateDeprecatedMethodRecipes` with columns for method pattern, replacement, and a copy-pasteable YAML snippet
- Each deprecated delegating method found by the scanner emits a row, making it easy to export inline recipes from OSS libraries without parsing the generated YAML file
- Includes a new test verifying data table row contents

## Test plan
- [x] All 17 existing tests pass
- [x] New `dataTable()` test verifies method pattern, replacement, and YAML snippet columns