### PR TITLE
Strip comments from replacement in GenerateDeprecatedMethodRecipes

### DIFF
--- a/src/main/java/org/openrewrite/java/recipes/GenerateDeprecatedMethodRecipes.java
+++ b/src/main/java/org/openrewrite/java/recipes/GenerateDeprecatedMethodRecipes.java
@@ -124,7 +124,11 @@ public class GenerateDeprecatedMethodRecipes extends ScanningRecipe<GenerateDepr
                             }
 
                             String replacement = methodCall.printTrimmed(getCursor())
-                                    .replaceAll("\\n\\s+", " ");
+                                    .replaceAll("/\\*[\\s\\S]*?\\*/", "")
+                                    .replaceAll("//[^\n]*", "")
+                                    .replaceAll("\\n\\s+", " ")
+                                    .replaceAll("  +", " ")
+                                    .trim();
                             String methodPattern = MethodMatcher.methodPattern(md.getMethodType());
                             acc.candidatesByProject
                                     .computeIfAbsent(javaProject, k -> new ArrayList<>())

--- a/src/main/java/org/openrewrite/java/recipes/GenerateDeprecatedMethodRecipes.java
+++ b/src/main/java/org/openrewrite/java/recipes/GenerateDeprecatedMethodRecipes.java
@@ -123,12 +123,14 @@ public class GenerateDeprecatedMethodRecipes extends ScanningRecipe<GenerateDepr
                                 return md;
                             }
 
-                            String replacement = methodCall.printTrimmed(getCursor())
-                                    .replaceAll("/\\*[\\s\\S]*?\\*/", "")
-                                    .replaceAll("//[^\n]*", "")
-                                    .replaceAll("\\n\\s+", " ")
-                                    .replaceAll("  +", " ")
-                                    .trim();
+                            J commentFree = (J) new JavaIsoVisitor<ExecutionContext>() {
+                                @Override
+                                public Space visitSpace(Space space, Space.Location loc, ExecutionContext ctx) {
+                                    return space.withComments(emptyList());
+                                }
+                            }.visitNonNull(methodCall, ctx);
+                            String replacement = commentFree.printTrimmed(getCursor())
+                                    .replaceAll("\\n\\s+", " ");
                             String methodPattern = MethodMatcher.methodPattern(md.getMethodType());
                             acc.candidatesByProject
                                     .computeIfAbsent(javaProject, k -> new ArrayList<>())

--- a/src/test/java/org/openrewrite/java/recipes/GenerateDeprecatedMethodRecipesTest.java
+++ b/src/test/java/org/openrewrite/java/recipes/GenerateDeprecatedMethodRecipesTest.java
@@ -317,6 +317,42 @@ class GenerateDeprecatedMethodRecipesTest implements RewriteTest {
     }
 
     @Test
+    void commentsInDelegationBodyStripped() {
+        rewriteRun(
+          java(
+            """
+              package com.example;
+
+              public class Commented {
+                  public void newMethod(String s, String defaultVal) {
+                  }
+
+                  @Deprecated
+                  public void oldMethod(String s) {
+                      newMethod(s, /* noinspection */ "default");
+                  }
+              }
+              """
+          ),
+          yaml(
+            doesNotExist(),
+            //language=yaml
+            """
+              type: specs.openrewrite.org/v1beta/recipe
+              name: org.openrewrite.recipes.InlineDeprecatedMethods
+              displayName: Inline deprecated delegating methods
+              description: Automatically generated recipes to inline deprecated method calls that delegate to other methods in the same class.
+              recipeList:
+                - org.openrewrite.java.InlineMethodCalls:
+                    methodPattern: 'com.example.Commented oldMethod(java.lang.String)'
+                    replacement: 'newMethod(s, "default")'
+              """,
+            spec -> spec.path("src/main/resources/META-INF/rewrite/inline-deprecated-methods.yml")
+          )
+        );
+    }
+
+    @Test
     void externalCallIgnored() {
         rewriteRun(
           java(


### PR DESCRIPTION
## Summary
- When a deprecated delegating method body contains comments (block or line), they were leaking into the generated YAML `replacement` string
- Added regex-based comment stripping before whitespace collapsing in the replacement extraction
- Added test verifying inline block comments between arguments are excluded from output

## Test plan
- [x] Existing tests pass
- [x] New `commentsInDelegationBodyStripped` test covers block comment removal