### PR TITLE
Skip cast in UseVisitWithParentCursor when invocation is a statement

### DIFF
--- a/src/main/java/org/openrewrite/java/recipes/UseVisitWithParentCursor.java
+++ b/src/main/java/org/openrewrite/java/recipes/UseVisitWithParentCursor.java
@@ -116,11 +116,16 @@ public class UseVisitWithParentCursor extends Recipe {
                         }
 
                         // Determine if the called method is iso-style (return type matches first param type)
-                        // and needs a cast since visit() returns Tree
+                        // and needs a cast since visit() returns Tree. Skip the cast when the parent
+                        // is already a cast, or when the invocation's return value is discarded (i.e. it
+                        // is a standalone statement in a block) - a cast expression would not be a valid
+                        // Java statement in that position.
+                        Object parent = getCursor().getParentTreeCursor().getValue();
                         JavaType returnType = mi.getMethodType().getReturnType();
                         boolean needsCast = TypeUtils.isOfType(returnType, firstParamType) &&
                                 returnType instanceof JavaType.FullyQualified &&
-                                !(getCursor().getParentTreeCursor().getValue() instanceof J.TypeCast);
+                                !(parent instanceof J.TypeCast) &&
+                                !(parent instanceof J.Block);
 
                         String templateStr;
                         if (needsCast) {

--- a/src/test/java/org/openrewrite/java/recipes/UseVisitWithParentCursorTest.java
+++ b/src/test/java/org/openrewrite/java/recipes/UseVisitWithParentCursorTest.java
@@ -229,6 +229,68 @@ class UseVisitWithParentCursorTest implements RewriteTest {
     }
 
     @Test
+    void doNotAddCastForStandaloneStatementInvocation() {
+        // When the invocation's return value is discarded (statement-expression context),
+        // adding a cast would produce `(Type) foo.visit(...);` which is not a valid Java
+        // statement, causing the template to generate 0 statements. In this case, emit
+        // the invocation without a cast.
+        rewriteRun(
+          java(
+            """
+              import org.openrewrite.*;
+              import org.openrewrite.java.JavaIsoVisitor;
+              import org.openrewrite.java.tree.J;
+
+              class MyRecipe extends Recipe {
+                  @Override
+                  public String getDisplayName() { return ""; }
+                  @Override
+                  public String getDescription() { return ""; }
+
+                  @Override
+                  public TreeVisitor<?, ExecutionContext> getVisitor() {
+                      return new JavaIsoVisitor<ExecutionContext>() {
+                          @Override
+                          public J.VariableDeclarations visitVariableDeclarations(J.VariableDeclarations multiVariable, ExecutionContext ctx) {
+                              J.VariableDeclarations m = super.visitVariableDeclarations(multiVariable, ctx);
+                              JavaIsoVisitor<ExecutionContext> delegate = new JavaIsoVisitor<ExecutionContext>() {};
+                              delegate.visitVariableDeclarations(multiVariable, ctx);
+                              return m;
+                          }
+                      };
+                  }
+              }
+              """,
+            """
+              import org.openrewrite.*;
+              import org.openrewrite.java.JavaIsoVisitor;
+              import org.openrewrite.java.tree.J;
+
+              class MyRecipe extends Recipe {
+                  @Override
+                  public String getDisplayName() { return ""; }
+                  @Override
+                  public String getDescription() { return ""; }
+
+                  @Override
+                  public TreeVisitor<?, ExecutionContext> getVisitor() {
+                      return new JavaIsoVisitor<ExecutionContext>() {
+                          @Override
+                          public J.VariableDeclarations visitVariableDeclarations(J.VariableDeclarations multiVariable, ExecutionContext ctx) {
+                              J.VariableDeclarations m = super.visitVariableDeclarations(multiVariable, ctx);
+                              JavaIsoVisitor<ExecutionContext> delegate = new JavaIsoVisitor<ExecutionContext>() {};
+                              delegate.visit(multiVariable, ctx, getCursor().getParentTreeCursor());
+                              return m;
+                          }
+                      };
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
     void doNotChangeSuperCall() {
         rewriteRun(
           java(


### PR DESCRIPTION
## Motivation

The `UseVisitWithParentCursor` recipe rewrites `visitor.visitXxx(tree, ctx)` into `visitor.visit(tree, ctx, getCursor().getParentTreeCursor())`, adding a cast for iso-style visitors so the expression keeps the specific return type. When the original invocation is a standalone statement whose return value is discarded, the recipe was still wrapping the replacement in a cast — producing `(Type) visitor.visit(...);`, which is not a valid Java statement. `JavaTemplate` then parses zero statements from the template and throws `IllegalArgumentException`.

Seen in the wild against `openrewrite/rewrite-spring`, e.g. `ConvertReceiveTypeWhenCallStepExecutionMethod`:

```java
VisitMethodInvocation visitMethodInvocation = new VisitMethodInvocation(selfMethodInvocation);
visitMethodInvocation.visitVariableDeclarations(multiVariable, ctx);  // return value ignored
if (visitMethodInvocation.isFound) {
    doAfterVisit(new AddCast());
}
```

## Examples

Before (would throw):

```java
JavaIsoVisitor<ExecutionContext> delegate = new JavaIsoVisitor<ExecutionContext>() {};
delegate.visitVariableDeclarations(multiVariable, ctx);
```

After:

```java
JavaIsoVisitor<ExecutionContext> delegate = new JavaIsoVisitor<ExecutionContext>() {};
delegate.visit(multiVariable, ctx, getCursor().getParentTreeCursor());
```

(No cast, because the cast would make the expression invalid as a statement — and the return value is discarded anyway.)

## Summary

- Skip the cast in `UseVisitWithParentCursor` when the invocation's parent is `J.Block`, i.e. the invocation is used as a statement-expression.
- Add a regression test `doNotAddCastForStandaloneStatementInvocation` reproducing the exact failure.

## Test plan

- [x] New test reproduces the original `IllegalArgumentException` on `main`.
- [x] Test passes with the fix.
- [x] All existing tests in `UseVisitWithParentCursorTest` continue to pass.
- [x] Full module `./gradlew test` is green.