### PR TITLE
Avoid renaming ExecutionContext parameter when it would shadow an outer scope

### DIFF
--- a/src/main/java/org/openrewrite/java/recipes/ExecutionContextParameterName.java
+++ b/src/main/java/org/openrewrite/java/recipes/ExecutionContextParameterName.java
@@ -21,6 +21,7 @@ import org.jspecify.annotations.Nullable;
 import org.openrewrite.*;
 import org.openrewrite.java.JavaIsoVisitor;
 import org.openrewrite.java.RenameVariable;
+import org.openrewrite.java.VariableNameUtils;
 import org.openrewrite.java.search.UsesType;
 import org.openrewrite.java.tree.J;
 import org.openrewrite.java.tree.Statement;
@@ -58,7 +59,8 @@ public class ExecutionContextParameterName extends Recipe {
                                 J.VariableDeclarations param = (J.VariableDeclarations) parameter;
                                 if (TypeUtils.isOfClassType(param.getType(), "org.openrewrite.ExecutionContext") &&
                                         !"delegate".equals(param.getVariables().get(0).getSimpleName()) &&
-                                        !param.getVariables().get(0).getSimpleName().startsWith(prefix)) {
+                                        !param.getVariables().get(0).getSimpleName().startsWith(prefix) &&
+                                        !VariableNameUtils.findNamesInScope(getCursor()).contains(prefix)) {
                                     m = (J.MethodDeclaration) new RenameVariable<ExecutionContext>(param.getVariables().get(0), prefix)
                                             .visitNonNull(m, ctx);
                                 }

--- a/src/test/java/org/openrewrite/java/recipes/ExecutionContextParameterNameTest.java
+++ b/src/test/java/org/openrewrite/java/recipes/ExecutionContextParameterNameTest.java
@@ -132,6 +132,25 @@ class ExecutionContextParameterNameTest implements RewriteTest {
     }
 
     @Test
+    void doNotRenameWhenItWouldShadowOuterScope() {
+        rewriteRun(
+          java(
+            """
+              import org.openrewrite.*;
+              class SampleRecipe extends Recipe {
+                  public void test(ExecutionContext ctx) {
+                      new Visitor() {
+                          public void visit(ExecutionContext c) {
+                          }
+                      };
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
     void doNotRenameDelegateParameter() {
         rewriteRun(
           java(


### PR DESCRIPTION
`ExecutionContextParameterName` unconditionally renamed an `ExecutionContext` parameter to `ctx`, even when an enclosing scope already bound that name — producing undesired shadowing in nested visitors (e.g. an inner `visitBlock` param inside a method that already has `ctx`). The rename is now skipped when `VariableNameUtils.findNamesInScope` already contains the target name, leaving the original parameter name untouched rather than introducing a shadow. Adds a regression test covering the nested-visitor shadowing case.