### PR TITLE
Fix UseRewriteTestDefaults corrupting output for classes with field initializers

### DIFF
--- a/src/main/java/org/openrewrite/java/recipes/UseRewriteTestDefaults.java
+++ b/src/main/java/org/openrewrite/java/recipes/UseRewriteTestDefaults.java
@@ -132,7 +132,8 @@ public class UseRewriteTestDefaults extends Recipe {
 
             private J.ClassDeclaration newlineBeforeFirstStatement(J.ClassDeclaration cd) {
                 return cd.withBody(cd.getBody().withStatements(ListUtils.mapFirst(cd.getBody().getStatements(),
-                        first -> first.withPrefix(first.getPrefix().withWhitespace("\n" + first.getPrefix().getWhitespace())))));
+                        first -> first.withPrefix(first.getPrefix().withWhitespace(
+                                "\n\n" + first.getPrefix().getWhitespace().replaceFirst("^\\n+", ""))))));
             }
 
             private J.ClassDeclaration addDefaultsMethod(J.ClassDeclaration cd, RecipeSpecInfo specInfo) {
@@ -143,7 +144,6 @@ public class UseRewriteTestDefaults extends Recipe {
                                             "public void defaults(RecipeSpec spec) {\n" +
                                             "    #{any()}\n" +
                                             "}")
-                            .contextSensitive()
                             .imports("org.openrewrite.test.RecipeSpec")
                             .javaParser(JavaParser.fromJavaVersion().classpath(JavaParser.runtimeClasspath()))
                             .build()

--- a/src/test/java/org/openrewrite/java/recipes/UseRewriteTestDefaultsTest.java
+++ b/src/test/java/org/openrewrite/java/recipes/UseRewriteTestDefaultsTest.java
@@ -473,6 +473,82 @@ class UseRewriteTestDefaultsTest implements RewriteTest {
     }
 
     @Test
+    void shouldHandleClassWithFieldInitializedByMethodCall() {
+        rewriteRun(
+          java(
+            """
+              import org.junit.jupiter.api.Test;
+              import org.openrewrite.test.RewriteTest;
+
+              import java.util.LinkedHashMap;
+              import java.util.Map;
+
+              class MyTest implements RewriteTest {
+
+                  private static final Map<String, String> PROPS = loadProperties();
+
+                  private static Map<String, String> loadProperties() {
+                      return new LinkedHashMap<>();
+                  }
+
+                  @Test
+                  void test1() {
+                      rewriteRun(
+                          spec -> spec.recipe(new org.openrewrite.java.recipes.MissingOptionExample()),
+                          org.openrewrite.java.Assertions.java("class A {}", "class A {}")
+                      );
+                  }
+
+                  @Test
+                  void test2() {
+                      rewriteRun(
+                          spec -> spec.recipe(new org.openrewrite.java.recipes.MissingOptionExample()),
+                          org.openrewrite.java.Assertions.java("class B {}", "class B {}")
+                      );
+                  }
+              }
+              """,
+            """
+              import org.junit.jupiter.api.Test;
+              import org.openrewrite.test.RecipeSpec;
+              import org.openrewrite.test.RewriteTest;
+
+              import java.util.LinkedHashMap;
+              import java.util.Map;
+
+              class MyTest implements RewriteTest {
+
+                  @Override
+                  public void defaults(RecipeSpec spec) {
+                      spec.recipe(new org.openrewrite.java.recipes.MissingOptionExample());
+                  }
+
+                  private static final Map<String, String> PROPS = loadProperties();
+
+                  private static Map<String, String> loadProperties() {
+                      return new LinkedHashMap<>();
+                  }
+
+                  @Test
+                  void test1() {
+                      rewriteRun(
+                          org.openrewrite.java.Assertions.java("class A {}", "class A {}")
+                      );
+                  }
+
+                  @Test
+                  void test2() {
+                      rewriteRun(
+                          org.openrewrite.java.Assertions.java("class B {}", "class B {}")
+                      );
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
     void shouldHandleMethodReference() {
         rewriteRun(
           java(


### PR DESCRIPTION
`UseRewriteTestDefaults` produced corrupted output (leaking JavaTemplate internals like `__P__` and `/*__TEMPLATE_STOP__*/`) when a test class had a field whose initializer calls a helper method before the test methods, as seen in `UpgradeOfficialGitHubActionsTest`. The lambda-case `JavaTemplate` used `contextSensitive()`, which re-parses the whole surrounding class and failed to stitch the tree back together for that structure. Since the lambda body is passed in as an already-type-attributed LST subtree, context sensitivity is unnecessary, so it's removed; the blank-line handling is also normalized to avoid a double blank line when the source already has one. Added a regression test reproducing the exact failing structure.