### PR TITLE
Avoid no-op change in SourceSpecTextBlockIndentation when margin is already minimal

### DIFF
--- a/src/main/java/org/openrewrite/java/recipes/SourceSpecTextBlockIndentation.java
+++ b/src/main/java/org/openrewrite/java/recipes/SourceSpecTextBlockIndentation.java
@@ -95,7 +95,12 @@ public class SourceSpecTextBlockIndentation extends Recipe {
                                         }
                                     }
 
-                                    return source.withValueSource(fixedSource.toString());
+                                    String fixed = fixedSource.toString();
+                                    if (fixed.equals(source.getValueSource())) {
+                                        // Nothing to trim (e.g. margin already minimal); avoid a no-op change
+                                        return argument;
+                                    }
+                                    return source.withValueSource(fixed);
                                 }
 
                             }

--- a/src/test/java/org/openrewrite/java/recipes/SourceSpecTextBlockIndentationTest.java
+++ b/src/test/java/org/openrewrite/java/recipes/SourceSpecTextBlockIndentationTest.java
@@ -35,7 +35,6 @@ class SourceSpecTextBlockIndentationTest implements RewriteTest {
     @Test
     void minimalIndentation() {
         rewriteRun(
-          spec -> spec.expectedCyclesThatMakeChanges(2),
           java(
             """
               import org.openrewrite.test.RewriteTest;
@@ -71,6 +70,34 @@ class SourceSpecTextBlockIndentationTest implements RewriteTest {
                            class Test {
               \s
                               \s
+                               void test() {
+                                   System.out.println("Hello, world!");
+                               }
+                           }
+                           \"""
+                       )
+                    );
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void doNotChangeWhenAlreadyMinimallyIndented() {
+        rewriteRun(
+          java(
+            """
+              import org.openrewrite.test.RewriteTest;
+              import static org.openrewrite.test.SourceSpecs.text;
+
+              class MyRecipeTest implements RewriteTest {
+                  void test() {
+                    rewriteRun(
+                       text(
+                         \"""
+                           class Test {
                                void test() {
                                    System.out.println("Hello, world!");
                                }


### PR DESCRIPTION
## What

`SourceSpecTextBlockIndentation` could report a change to a source file while producing byte-for-byte identical output — a phantom no-op change.

When a `SourceSpecs` text block is already minimally indented, `marginTrim` (`indentations[0] - expectedIndent`) is `0`. The re-indentation loop then calls `line.substring(0)` on every line, reconstructing the exact original string, but the code still called `source.withValueSource(fixedSource.toString())`. Because `fixedSource.toString()` is a fresh `String` instance and Lombok's `withValueSource` compares by reference, this returned a new `J.Literal` and registered a change even though nothing was rewritten.

The existing `minimalIndentation` test was masking this by asserting `expectedCyclesThatMakeChanges(2)`: cycle 1 did the real re-indentation, cycle 2 was this phantom no-op.

## Why it matters

A recipe result whose before/after print identically is a phantom change. Beyond violating the single-cycle convention, it flags files as changed when they aren't. As part of the `OpenRewriteRecipeBestPractices` aggregate run against `openrewrite/rewrite-spring`, this caused test files like `MigrateRestTemplateBuilderTimeoutByIntTest.java` to be reported as modified/deleted in results even though the recipe made no textual change to them.

## Change

- Only call `withValueSource` when the recomputed source actually differs; otherwise return the argument unchanged.
- Drop the now-unnecessary `expectedCyclesThatMakeChanges(2)` from the existing test (it now stabilizes in a single cycle).
- Add a regression test asserting an already-minimally-indented text block is left untouched.